### PR TITLE
add setup function to prompt themes

### DIFF
--- a/modules/prompt/functions/ext-liquidprompt
+++ b/modules/prompt/functions/ext-liquidprompt
@@ -1,0 +1,1 @@
+../external-themes/liquidprompt/liquidprompt

--- a/modules/prompt/functions/prompt_liquidprompt_setup
+++ b/modules/prompt/functions/prompt_liquidprompt_setup
@@ -1,1 +1,15 @@
-../external-themes/liquidprompt/liquidprompt
+function prompt_liquidprompt_setup() {
+    autoload -Uz ex-liquidprompt
+
+    ext-liquidprompt
+    prompt_opts=(cr subst percent)
+}
+
+function prompt_liquidprompt_preview() {
+    _lp_set_prompt
+    prompt_preview_theme liquidprompt
+}
+
+prompt_liquidprompt_setup "$@"
+
+# vim:filetype=zsh

--- a/modules/prompt/themes/gitster.zsh-theme
+++ b/modules/prompt/themes/gitster.zsh-theme
@@ -3,12 +3,11 @@
 # https://github.com/shashankmehta/dotfiles/blob/master/thesetup/zsh/.oh-my-zsh/custom/themes/gitster.zsh-theme
 #
 
-autoload -Uz colors && colors
-prompt_opts=( cr subst percent )
+function gst_get_status(){
+  print "%(?:%F{10}➜ :%F{9}➜ %s)"
+}
 
-local ret_status="%(?:%{$fg_bold[green]%}➜ :%{$fg_bold[red]%}➜ %s)"
-
-function get_pwd(){
+function gst_get_pwd(){
   git_root=$PWD
   while [[ $git_root != / && ! -e $git_root/.git ]]; do
     git_root=$git_root:h
@@ -23,9 +22,20 @@ function get_pwd(){
   print $prompt_short_dir
 }
 
-PROMPT='$ret_status %{$fg[white]%}$(get_pwd) $(git_prompt_info)%{$reset_color%}%{$reset_color%} '
+function prompt_gitster_precmd(){
+  PROMPT='$(gst_get_status) %F{white}$(gst_get_pwd) $(git_prompt_info)%f '
+}
 
-ZSH_THEME_GIT_PROMPT_PREFIX="%{$fg[cyan]%}"
-ZSH_THEME_GIT_PROMPT_SUFFIX="%{$reset_color%}"
-ZSH_THEME_GIT_PROMPT_DIRTY=" %{$fg[yellow]%}✗%{$reset_color%}"
-ZSH_THEME_GIT_PROMPT_CLEAN=" %{$fg[green]%}✓%{$reset_color%}"
+function prompt_gitster_setup(){
+  ZSH_THEME_GIT_PROMPT_PREFIX="%F{cyan}"
+  ZSH_THEME_GIT_PROMPT_SUFFIX="%f"
+  ZSH_THEME_GIT_PROMPT_DIRTY=" %F{yellow}✗%f"
+  ZSH_THEME_GIT_PROMPT_CLEAN=" %F{green}✓%f"
+
+  autoload -Uz add-zsh-hook
+
+  add-zsh-hook precmd prompt_gitster_precmd
+  prompt_opts=(cr subst percent)
+}
+
+prompt_gitster_setup "$@"

--- a/modules/prompt/themes/minimal.zsh-theme
+++ b/modules/prompt/themes/minimal.zsh-theme
@@ -3,26 +3,33 @@
 # https://github.com/S1cK94/minimal
 #
 
-autoload -Uz colors && colors
-
-prompt_opts=( cr subst percent )
-
-PROMPT_CHAR="❯"
-
-ON_COLOR="%{$fg[green]%}"
-OFF_COLOR="%{$reset_color%}"
-ERR_COLOR="%{$fg[red]%}"
-
-function prompt_user() {
-  echo "%(!.$ON_COLOR.$OFF_COLOR)$PROMPT_CHAR%{$reset_color%}"
+function minimal_user() {
+  echo "%(!.$on_color.$off_color)$prompt_char%f"
 }
 
-function prompt_jobs() {
-  echo "%(1j.$ON_COLOR.$OFF_COLOR)$PROMPT_CHAR%{$reset_color%}"
+function minimal_jobs() {
+  echo "%(1j.$on_color.$off_color)$prompt_char%f"
 }
 
-function prompt_status() {
-  echo "%(0?.$ON_COLOR.$ERR_COLOR)$PROMPT_CHAR%{$reset_color%}"
+function minimal_vimode(){
+  local ret=""
+
+  case $KEYMAP in
+    main|viins)
+      ret+="$on_color"
+      ;;
+    vicmd)
+      ret+="$off_color"
+      ;;
+  esac
+
+  ret+="$prompt_char%f"
+
+  echo "$ret"
+}
+
+function minimal_status() {
+  echo "%(0?.$on_color.$err_color)$prompt_char%f"
 }
 
 function -prompt_ellipse(){
@@ -35,12 +42,12 @@ function -prompt_ellipse(){
   fi
 }
 
-function prompt_path() {
-  local path_color="%{[38;5;244m%}%}"
-  local rsc="%{$reset_color%}"
+function minimal_path() {
+  local path_color="%F{244}"
+  local rsc="%f"
   local sep="$rsc/$path_color"
 
-  echo "$path_color$(print -P %2~ | sed s_/_${sep}_g)$rsc"
+  echo "$path_color$(sed s_/_${sep}_g <<< $(short_pwd))$rsc"
 }
 
 function git_branch_name() {
@@ -52,41 +59,24 @@ function git_repo_status(){
   local rs="$(git status --porcelain -b)"
 
   if $(echo "$rs" | grep -v '^##' &> /dev/null); then # is dirty
-    echo "%{$fg[red]%}"
+    echo "%F{red}"
   elif $(echo "$rs" | grep '^## .*diverged' &> /dev/null); then # has diverged
-    echo "%{$fg[red]%}"
+    echo "%F{red}"
   elif $(echo "$rs" | grep '^## .*behind' &> /dev/null); then # is behind
-    echo "%{[38;5;011m%}%}"
+    echo "%F{11}"
   elif $(echo "$rs" | grep '^## .*ahead' &> /dev/null); then # is ahead
-    echo "%{$reset_color%}"
+    echo "%f"
   else # is clean
-    echo "%{$fg[green]%}"
+    echo "%F{green}"
   fi
 }
 
-function prompt_git() {
+function minimal_git() {
   local bname=$(git_branch_name)
   if [[ -n $bname ]]; then
-    local infos="$(git_repo_status)$bname%{$reset_color%}"
+    local infos="$(git_repo_status)$bname%f"
     echo " $infos"
   fi
-}
-
-function prompt_vimode(){
-  local ret=""
-
-  case $KEYMAP in
-    main|viins)
-      ret+="$ON_COLOR"
-      ;;
-    vicmd)
-      ret+="$OFF_COLOR"
-      ;;
-  esac
-
-  ret+="$PROMPT_CHAR%{$reset_color%}"
-
-  echo "$ret"
 }
 
 function zle-line-init zle-line-finish zle-keymap-select {
@@ -94,10 +84,25 @@ function zle-line-init zle-line-finish zle-keymap-select {
   zle -R
 }
 
-zle -N zle-line-init
-zle -N zle-keymap-select
-zle -N zle-line-finish
+function prompt_minimal_precmd() {
+  zle -N zle-line-init
+  zle -N zle-keymap-select
+  zle -N zle-line-finish
 
-PROMPT='$(prompt_user)$(prompt_jobs)$(prompt_vimode)$(prompt_status) '
-RPROMPT='$(prompt_path)$(prompt_git)'
+  PROMPT='$(minimal_user)$(minimal_jobs)$(minimal_vimode)$(minimal_status) '
+  RPROMPT='$(minimal_path)$(minimal_git)'
+}
 
+function prompt_minimal_setup() {
+  prompt_char="❯"
+  on_color="%F{green}"
+  off_color="%f"
+  err_color="%F{red}"
+
+  autoload -Uz add-zsh-hook
+
+  add-zsh-hook precmd prompt_minimal_precmd
+  prompt_opts=(cr subst percent)
+}
+
+prompt_minimal_setup "$@"

--- a/modules/prompt/themes/steeef.zsh-theme
+++ b/modules/prompt/themes/steeef.zsh-theme
@@ -12,55 +12,6 @@ export VIRTUAL_ENV_DISABLE_PROMPT=1
 function virtualenv_info {
     [ $VIRTUAL_ENV ] && print '('${fg[blue]}`basename $VIRTUAL_ENV`%{${reset_color}%}') '
 }
-PR_GIT_UPDATE=1
-
-prompt_opts=( cr subst percent )
-
-autoload -Uz add-zsh-hook
-autoload -Uz vcs_info
-autoload -Uz colors && colors
-
-#use extended color pallete if available
-if [[ ${TERM} == *256* || ${TERM} == *rxvt* ]]; then
-    turquoise="%F{81}"
-    orange="%F{166}"
-    purple="%F{135}"
-    hotpink="%F{161}"
-    limegreen="%F{118}"
-else
-    turquoise="$fg[cyan]"
-    orange="$fg[yellow]"
-    purple="$fg[magenta]"
-    hotpink="$fg[red]"
-    limegreen="$fg[green]"
-fi
-
-# enable VCS systems you use
-zstyle ':vcs_info:*' enable git svn
-
-# check-for-changes can be really slow.
-# you should disable it, if you work with large repositories
-zstyle ':vcs_info:*:prompt:*' check-for-changes true
-
-# set formats
-# %b - branchname
-# %u - unstagedstr (see below)
-# %c - stagedstr (see below)
-# %a - action (e.g. rebase-i)
-# %R - repository path
-# %S - path in the repository
-PR_RST="%{${reset_color}%}"
-FMT_BRANCH="(%{$turquoise%}%b%u%c${PR_RST})"
-FMT_ACTION="(%{$limegreen%}%a${PR_RST})"
-FMT_UNSTAGED="%{$orange%}●"
-FMT_STAGED="%{$limegreen%}●"
-
-zstyle ':vcs_info:*:prompt:*' unstagedstr   "${FMT_UNSTAGED}"
-zstyle ':vcs_info:*:prompt:*' stagedstr     "${FMT_STAGED}"
-zstyle ':vcs_info:*:prompt:*' actionformats "${FMT_BRANCH}${FMT_ACTION}"
-zstyle ':vcs_info:*:prompt:*' formats       "${FMT_BRANCH}"
-zstyle ':vcs_info:*:prompt:*' nvcsformats   ""
-
 
 function steeef_preexec {
     case "$(history $HISTCMD)" in
@@ -72,14 +23,12 @@ function steeef_preexec {
             ;;
     esac
 }
-add-zsh-hook preexec steeef_preexec
 
 function steeef_chpwd {
     PR_GIT_UPDATE=1
 }
-add-zsh-hook chpwd steeef_chpwd
 
-function steeef_precmd {
+function prompt_steeef_precmd {
     if [[ -n "$PR_GIT_UPDATE" ]] ; then
         # check for untracked files or updated submodules, since vcs_info doesn't
         if git ls-files --other --exclude-standard 2> /dev/null | grep -q "."; then
@@ -93,9 +42,64 @@ function steeef_precmd {
         vcs_info 'prompt'
         PR_GIT_UPDATE=
     fi
-}
-add-zsh-hook precmd steeef_precmd
 
-PROMPT='
+    PROMPT='
 %{$purple%}%n${${reset_color}%} at %{$orange%}%m${${reset_color}%} in %{$limegreen%}%~${${reset_color}%} $vcs_info_msg_0_$(virtualenv_info)%{${reset_color}%}
 $ '
+}
+
+function prompt_steeef_setup {
+    #use extended color pallete if available
+    if [[ ${TERM} == *256* || ${TERM} == *rxvt* ]]; then
+        turquoise="%F{81}"
+        orange="%F{166}"
+        purple="%F{135}"
+        hotpink="%F{161}"
+        limegreen="%F{118}"
+    else
+        turquoise="%F{cyan}"
+        orange="%F{yellow}"
+        purple="%F{magenta}"
+        hotpink="%F{red}"
+        limegreen="%F{green}"
+    fi
+
+    # enable VCS systems you use
+    zstyle ':vcs_info:*' enable git svn
+
+    # check-for-changes can be really slow.
+    # you should disable it, if you work with large repositories
+    zstyle ':vcs_info:*:prompt:*' check-for-changes true
+
+    # set formats
+    # %b - branchname
+    # %u - unstagedstr (see below)
+    # %c - stagedstr (see below)
+    # %a - action (e.g. rebase-i)
+    # %R - repository path
+    # %S - path in the repository
+    PR_RST="%f"
+    FMT_BRANCH="(%{$turquoise%}%b%u%c${PR_RST})"
+    FMT_ACTION="(%{$limegreen%}%a${PR_RST})"
+    FMT_UNSTAGED="%{$orange%}●"
+    FMT_STAGED="%{$limegreen%}●"
+
+    zstyle ':vcs_info:*:prompt:*' unstagedstr   "${FMT_UNSTAGED}"
+    zstyle ':vcs_info:*:prompt:*' stagedstr     "${FMT_STAGED}"
+    zstyle ':vcs_info:*:prompt:*' actionformats "${FMT_BRANCH}${FMT_ACTION}"
+    zstyle ':vcs_info:*:prompt:*' formats       "${FMT_BRANCH}"
+    zstyle ':vcs_info:*:prompt:*' nvcsformats   ""
+
+    PR_GIT_UPDATE=1
+
+    autoload -Uz add-zsh-hook
+    autoload -Uz vcs_info
+    autoload -Uz colors && colors
+
+    add-zsh-hook preexec steeef_preexec
+    add-zsh-hook chpwd steeef_chpwd
+    add-zsh-hook precmd prompt_steeef_precmd
+    prompt_opts=(cr subst percent)
+}
+
+prompt_steeef_setup "$@"


### PR DESCRIPTION
Addresses #12 

Refactor the themes to have a structure similar to zsh default themes.

Include a `prompt_$theme_setup` in all themes and rename functions to prevent them from sharing the same name on different files. This fixes a issue where some information was not being displayed after the themes preview.

To fix `liquidprompt`, I renamed the symlink and added a small wrapper setup to load the prompt and display it when calling `prompt -p`.
It's more a workaround since the theme is an external module.

From my tests, the issues are fixed.
If not, let me know and I'll look into it.