### PR TITLE
separate declaration and initialization of local array variable

### DIFF
--- a/modules/git/functions/parse_git_dirty
+++ b/modules/git/functions/parse_git_dirty
@@ -2,7 +2,7 @@
 # not supporting git < 1.7.2; upgrade your shit
 
 local STATUS=''
-local FLAGS=('--porcelain' '--ignore-submodules=dirty')
+local FLAGS; FLAGS=('--porcelain' '--ignore-submodules=dirty')
 if [[ ${zgit_hide_prompt} != 'true' ]]; then
   if [[ "${zgit_disable_untracked_dirty}" == "true" ]]; then
     FLAGS+='--untracked-files=no'


### PR DESCRIPTION
In my zsh (zsh 5.0.5 (x86_64-apple-darwin14.0)), the below error occurs when I set the "gitster" as prompt theme.
(below dotfiles is a git repository)

```sh
➜  ~/p/dotfiles master <ENTER>
parse_git_dirty:5: unknown sort specifier
➜  ~/p/dotfiles master
```

The error doesn't occurs in the latest homebrew zsh (zsh 5.2).

I made sure modules/git/functions/parse_git_dirty causes the error.
The old zsh may be not able to declare and initialize local array.