### PR TITLE
[prompt] fix gitster prompt

### DIFF
--- a/modules/prompt/functions/short_pwd
+++ b/modules/prompt/functions/short_pwd
@@ -1,7 +1,9 @@
 # shortens the pwd for use in prompt
 
-local current_dir="${PWD/#${HOME}/~}"
+local current_dir="${1:-${PWD}}"
 local return_dir='~'
+
+current_dir="${current_dir/#${HOME}/~}"
 
 # if we aren't in ~
 if [[ ${current_dir} != '~' ]]; then

--- a/modules/prompt/themes/gitster.zsh-theme
+++ b/modules/prompt/themes/gitster.zsh-theme
@@ -8,17 +8,9 @@ gst_get_status() {
 }
 
 gst_get_pwd() {
-  git_root=${PWD}
-  while [[ ${git_root} != / && ! -e ${git_root}/.git ]]; do
-    git_root=${git_root:h}
-  done
-  if [[ ${git_root} = / ]]; then
-    unset git_root
-    prompt_short_dir="$(short_pwd)"
-  else
-    parent=${git_root%\/*}
-    prompt_short_dir=${"$(short_pwd)"#${parent}/}
-  fi
+  prompt_short_dir="$(short_pwd)"
+  git_root="$(command git rev-parse --show-toplevel 2> /dev/null)" && \
+  prompt_short_dir="${prompt_short_dir#${$(short_pwd $git_root):h}/}"
   print ${prompt_short_dir}
 }
 


### PR DESCRIPTION
Currently, `gitster's` prompt is not working as intended.
Looking at the code, I'd expect the prompt to show the current path **starting from** the git root (if inside a git managed folder). Otherwise, show the normal output of `short_pwd`.
However, the full (shortened) path is shown instead. The problem is that the previous author mixes `PWD` and `short_pwd`, thus breaking the substitutions.

I added an optional parameter to `short_pwd` and re-use this function to also shorten the output of `git rev-parse --top-level`. This way, the substring matches will succeed.