### PR TITLE
Added doas-sudo - inserts doas or sudo before current command

### DIFF
--- a/modules/utility/init.zsh
+++ b/modules/utility/init.zsh
@@ -118,3 +118,20 @@ fi
 mkcd() {
   [[ -n ${1} ]] && mkdir -p ${1} && builtin cd ${1}
 }
+
+# Inserts 'doas ' or 'sudo ' at the beginning of a line.
+function prepend-sudoas {
+  if [[ "$BUFFER" != (doas|su(do|))\ * ]]; then
+    if [[ $OSTYPE == openbsd* ]]; then
+      BUFFER="doas $BUFFER"
+    else
+      BUFFER="sudo $BUFFER"
+    fi
+    (( CURSOR += 5 ))
+  fi
+}
+zle -N prepend-sudoas
+
+# Defined shortcut keys: [Esc] [Esc]
+bindkey "\e!" prepend-sudoas
+


### PR DESCRIPTION
Small function that adds sudo (or doas on OpenBSD), before a command. 

Using `!! command` is _not_ an equivalent, as you can use this function _before_ you made the mistake of forgetting sudo.

The short-cut is in line with other zsh short-cuts, like `<esc>h` to open a man-page.

The snippet should follow coding guidelines etc, but let me know if not.
