### PR TITLE
[prompt] add ranger prompt to eriner theme

### DIFF
--- a/modules/prompt/themes/eriner.zsh-theme
+++ b/modules/prompt/themes/eriner.zsh-theme
@@ -72,6 +72,16 @@ prompt_context() {
   fi
 }
 
+# Ranger: <https://github.com/ranger/ranger>, which can spawn ${SHELL}
+# under its own process
+prompt_ranger() {
+  if [[ $((RANGER_LEVEL)) -ne 0 ]]; then
+    local color=blue
+    prompt_segment ${color} ${PRIMARY_FG}
+    print -Pn " r"
+  fi
+}
+
 # Git: branch/detached head, dirty status
 prompt_git() {
   local color ref
@@ -122,6 +132,7 @@ prompt_eriner_main() {
   CURRENT_BG='NONE'
   prompt_status
   prompt_context
+  prompt_ranger
   prompt_dir
   prompt_git
   prompt_end


### PR DESCRIPTION
I often forget if I'm in a shell under a ranger instance or not, so I prefix an ` r` before the current directory to remind me. While a `ranger` prefix would be expected, it makes the prompt a bit too long, and because it only appears in a shell under ranger, the user would be able to figure out what it means, I believe.

I experimented with including `RANGER_LEVEL` in the prompt also, as it is incremented for every ranger level, but I couldn't figure out how to format it except for `r[0-9-n]`, which I felt was superfluous.

![prompt](https://bad.dragons.rocks/sY1w)