### PR TITLE
[steeef] Different prompt for privileged users

### DIFF
--- a/modules/prompt/themes/steeef.zsh-theme
+++ b/modules/prompt/themes/steeef.zsh-theme
@@ -43,7 +43,7 @@ prompt_steeef_precmd() {
 
   PROMPT='
 %{$purple%}%n${${reset_color}%} at %{$orange%}%m${${reset_color}%} in %{$limegreen%}%~${${reset_color}%} $vcs_info_msg_0_$(virtualenv_info)%{${reset_color}%}
-$ '
+%(!.#.$) '
 }
 
 prompt_steeef_setup() {


### PR DESCRIPTION
Use `%(!.#.$)` which will display `$` for normal users and `#` for privileged users