### PR TITLE
Add PageUp/Down for navigating through history.

### DIFF
--- a/modules/input/init.zsh
+++ b/modules/input/init.zsh
@@ -61,6 +61,14 @@ if [[ -n "${key_info[End]}" ]]; then
   bindkey "${key_info[End]}" end-of-line
 fi
 
+if [[ -n "${key_info[PageUp]}" ]]; then
+  bindkey "${key_info[PageUp]}" up-line-or-history
+fi
+
+if [[ -n "${key_info[PageDown]}" ]]; then
+  bindkey "${key_info[PageDown]}" down-line-or-history
+fi
+
 if [[ -n "${key_info[Insert]}" ]]; then
   bindkey "${key_info[Insert]}" overwrite-mode
 fi


### PR DESCRIPTION
Incredibly useful when combined history-substring-search and/or a laptop keyboard.

I've tested this and it works fine, and since PageUp/Down isn't binded to anything in Zim I thought it would be a nice addition.