### PR TITLE
Fix #75: Mac OS X doesn't recognize -o for uname

### DIFF
--- a/modules/debug/functions/trace-zim
+++ b/modules/debug/functions/trace-zim
@@ -32,10 +32,10 @@ Deleting old logs now..."
 fi
 
 # get some basic system information (kernel and zsh version)
-print "Zsh version: 
+print "Zsh version:
   $(zsh --version)
 Kernel information:
-  $(uname -mosr)
+  $(uname -a)
 fpath info:
   ${fpath}" >! /tmp/ztrace/sysinfo
 

--- a/tools/zim_info
+++ b/tools/zim_info
@@ -6,4 +6,4 @@ cd ${ZDOTDIR:-${HOME}}/.zim
 
 print "Zim commit ref:   $(command git rev-parse --short HEAD)"
 print "Zsh version:      $(command zsh --version)"
-print "System info:      $(command uname -mosr)"
+print "System info:      $(command uname -a)"

--- a/tools/zim_issue
+++ b/tools/zim_issue
@@ -30,7 +30,7 @@ cd ${ZDOTDIR:-${HOME}}/.zim
 git_dirty=$(command git status --porcelain 2>/dev/null | tail -n1)
 git_ref=$(command git rev-parse --short HEAD)
 zsh_version=$(zsh --version)
-operating_sys=$(uname -mosr)
+operating_sys=$(uname -a)
 
 
 


### PR DESCRIPTION
In `tools/zim_info`, conditionally call `uname` with different parameters depending on the operational system type.

Also fix `uname` calls with `-o` parameter in `trace-zim` and `zim_issue` files. A oneliner was preferred at `trace-zim` to avoid making the code more complex.