### PR TITLE
Pull latest commit from master for submodules when updating

### DIFF
--- a/tools/zim_update
+++ b/tools/zim_update
@@ -8,4 +8,4 @@ cd ${ZDOTDIR:-${HOME}/.zim}
 git remote update -p
 git merge --ff-only @\{u\}
 # and update the submodules
-git submodule update --init --recursive
+git submodule foreach --quiet --recursive git pull origin master


### PR DESCRIPTION
Instead of using `git submodule update`, that will keep the same commit specified in the containing repository index.