### PR TITLE
Use `uname -a` to prevent OS conflicts, one more occurrence I missed

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -6,7 +6,7 @@ For bug reports, please provide the following information:
 - gist of .zimrc:
 - Zsh version:
 - gist of .zshrc:
-- $(uname -mosr):
+- $(uname -a):
 
 Description
 -----------


### PR DESCRIPTION
Missed this one when creating https://github.com/Eriner/zim/pull/79
