### PR TITLE
Fix #85: Prompt is blank after <Tab><Tab><Ctrl-C>

### DIFF
--- a/modules/input/init.zsh
+++ b/modules/input/init.zsh
@@ -102,6 +102,15 @@ if [[ -n "${key_info[BackTab]}" ]]; then
   bindkey "${key_info[BackTab]}" reverse-menu-complete
 fi
 
+# Redisplay after completing, and avoid blank prompt after <Tab><Tab><Ctrl-C>
+expand-or-complete-with-redisplay() {
+  print -n '...'
+  zle expand-or-complete
+  zle redisplay
+}
+zle -N expand-or-complete-with-redisplay
+bindkey "${key_info[Control]}I" expand-or-complete-with-redisplay
+
 # Put into application mode and validate ${terminfo}
 zle-line-init() {
   if (( ${+terminfo[smkx]} )); then


### PR DESCRIPTION
The issue is fixed by adding `zle redisplay` after `zle expand-and-complete` for the expand-and-complete key binding. An additional `print -n '...'` was also included to show an indicator while the menu is loading, and that is purely cosmetic.

There's still one glitch: the prompt jumps one line up after <kbd>Tab</kbd><kbd>Tab</kbd><kbd>Ctrl-C</kbd>. This was observed in Prezto too.