### PR TITLE
Simplify utility module configuration

### DIFF
--- a/modules/utility/init.zsh
+++ b/modules/utility/init.zsh
@@ -3,14 +3,6 @@
 #
 
 #
-# Command Correction
-#
-
-if [[ ${zcorrection} == 'true' ]]; then
-  setopt CORRECT
-fi
-
-#
 # ls Colours
 #
 
@@ -23,7 +15,7 @@ if (( ${+commands[dircolors]} )); then
   fi
 
   alias ls='ls --group-directories-first --color=auto'
-  
+
 else
   # BSD
 

--- a/templates/zimrc
+++ b/templates/zimrc
@@ -38,9 +38,9 @@ zprompt_theme='steeef'
 # Utility
 #
 
-# Uncomment to enable command correction prompts; 'setopt CORRECT'
+# Uncomment to enable command correction prompts
 # See: http://zsh.sourceforge.net/Doc/Release/Options.html#Input_002fOutput
-#zcorrection='true'
+#setopt CORRECT
 
 #
 # Input


### PR DESCRIPTION
For `setopt CORRECT`. Let the user uncomment a line with the `setopt` directly in the configuration file, instead of having a flag variable for it.