### PR TITLE
[pacman] Add pacI alias to install without syncing

### DIFF
--- a/modules/pacman/init.zsh
+++ b/modules/pacman/init.zsh
@@ -54,6 +54,9 @@ alias pacb='makepkg -sci'
 # install, sync, and upgrade packages
 alias paci="${zpacman_frontend_priv} -Syu"
 
+# install packages without syncing
+alias pacI="${zpacman_frontend_priv} -S"
+
 # install, sync, and upgrade packages (forcibly refresh package lists)
 alias pacu="${zpacman_frontend_priv} -Syyu"
 


### PR DESCRIPTION
I often want to install a package without syncing and updating at the same time.
I'd like to see this alias, which I use for a couple of months now locally, merged into zim :)
