### PR TITLE
rescope usage to local so it doen't leak out into the shell

### DIFF
--- a/modules/meta/functions/zmanage
+++ b/modules/meta/functions/zmanage
@@ -1,4 +1,4 @@
-usage="${0} [action]
+local usage="${0} [action]
 Actions:
     | update      | Fetches and merges upstream zim commits if possible |
     | info        | Prints zim and system info                          |


### PR DESCRIPTION
Noticed zmanage leaked usage to global scope, so I tagged a quick local on it.

