### PR TITLE
Add less colour, and less or more as default PAGER

### DIFF
--- a/modules/environment/init.zsh
+++ b/modules/environment/init.zsh
@@ -21,7 +21,7 @@ fi
 # Treat single word simple commands without redirection as candidates for resumption of an existing job.
 setopt AUTO_RESUME
 
-# List jobs in the long format by default. 
+# List jobs in the long format by default.
 setopt LONG_LIST_JOBS
 
 # Report the status of background jobs immediately, rather than waiting until just before printing a prompt.
@@ -33,7 +33,16 @@ unsetopt BG_NICE
 # Send the HUP signal to running jobs when the shell exits.
 unsetopt HUP
 
-# Report the status of background and suspended jobs before exiting a shell with job control; 
-# a second attempt to exit the shell will succeed. 
-# NO_CHECK_JOBS is best used only in combination with NO_HUP, else such jobs will be killed automatically
+# Report the status of background and suspended jobs before exiting a shell with job control;
+# a second attempt to exit the shell will succeed.
+# NO_CHECK_JOBS is best used only in combination with NO_HUP, else such jobs will be killed automatically.
 unsetopt CHECK_JOBS
+
+# Set less or more as the default pager.
+if [[ -z ${PAGER} ]]; then
+  if (( ${+commands[less]} )); then
+    export PAGER=less
+  else
+    export PAGER=more
+  fi
+fi

--- a/modules/utility/README.md
+++ b/modules/utility/README.md
@@ -3,7 +3,7 @@ Utility
 
 Utility aliases and functions.
 
-Adds colour to `ls` and `grep`.
+Adds colour to `ls`, `grep` and `less`.
 
 Aliases
 -------
@@ -30,7 +30,7 @@ Aliases `get` to ( `aria2c` || `axel` || `wget` || `curl` ).
 
 | alias | command |
 | ----- | ------- |
-| `df` | `df -kh` | 
+| `df` | `df -kh` |
 | `du` | `du -kh` |
 
 ### Condoms

--- a/modules/utility/init.zsh
+++ b/modules/utility/init.zsh
@@ -3,49 +3,59 @@
 #
 
 #
-# ls Colours
+# Colours
 #
 
-if (( ${+commands[dircolors]} )); then
-  # GNU
-  if [[ -s ${HOME}/.dir_colors ]]; then
-    eval "$(dircolors --sh ${HOME}/.dir_colors)"
+if (( ${terminfo[colors]} >= 8 )); then
+  # ls Colors
+  if (( ${+commands[dircolors]} )); then
+    # GNU
+    if [[ -s ${HOME}/.dir_colors ]]; then
+      eval "$(dircolors --sh ${HOME}/.dir_colors)"
+    else
+      eval "$(dircolors --sh)"
+    fi
+
+    alias ls='ls --group-directories-first --color=auto'
+
   else
-    eval "$(dircolors --sh)"
+    # BSD
+
+    # colours for ls and completion
+    export LSCOLORS='exfxcxdxbxGxDxabagacad'
+    export LS_COLORS='di=34:ln=35:so=32:pi=33:ex=31:bd=36;01:cd=33;01:su=31;40;07:sg=36;40;07:tw=32;40;07:ow=33;40;07:'
+
+    # stock OpenBSD ls does not support colors at all, but colorls does.
+    if [[ $OSTYPE == openbsd* ]]; then
+      if (( ${+commands[colorls]} )); then
+        alias ls='colorls -G'
+      fi
+    else
+      alias ls='ls -G'
+    fi
   fi
 
-  alias ls='ls --group-directories-first --color=auto'
-
-else
-  # BSD
-
-  # colors for ls and completion
-  export LSCOLORS='exfxcxdxbxGxDxabagacad'
-  export LS_COLORS='di=34:ln=35:so=32:pi=33:ex=31:bd=36;01:cd=33;01:su=31;40;07:sg=36;40;07:tw=32;40;07:ow=33;40;07:'
-
-  # stock OpenBSD ls does not support colors at all, but colorls does.
-  if [[ $OSTYPE == openbsd* ]]; then
-    if (( ${+commands[colorls]} )); then
-      alias ls='colorls -G'
+  # grep Colours
+  export GREP_COLOR='37;45'             #BSD
+  export GREP_COLORS="mt=${GREP_COLOR}" #GNU
+  if [[ ${OSTYPE} == openbsd* ]]; then
+    if (( ${+commands[ggrep]} )); then
+      alias grep='ggrep --color=auto'
     fi
   else
-    alias ls='ls -G'
+   alias grep='grep --color=auto'
   fi
-fi
 
-
-#
-# grep Colours
-#
-
-export GREP_COLOR='37;45'             #BSD
-export GREP_COLORS="mt=${GREP_COLOR}" #GNU
-if [[ ${OSTYPE} == openbsd* ]]; then
-  if (( ${+commands[ggrep]} )); then
-    alias grep='ggrep --color=auto'
+  # less Colours
+  if [[ ${PAGER} == 'less' ]]; then
+    export LESS_TERMCAP_mb=$'\E[1;31m'    # Begins blinking.
+    export LESS_TERMCAP_md=$'\E[1;31m'    # Begins bold.
+    export LESS_TERMCAP_me=$'\E[0m'       # Ends mode.
+    export LESS_TERMCAP_se=$'\E[0m'       # Ends standout-mode.
+    export LESS_TERMCAP_so=$'\E[7m'       # Begins standout-mode.
+    export LESS_TERMCAP_ue=$'\E[0m'       # Ends underline.
+    export LESS_TERMCAP_us=$'\E[1;32m'    # Begins underline.
   fi
-else
- alias grep='grep --color=auto'
 fi
 
 
@@ -54,7 +64,7 @@ fi
 #
 
 alias l='ls -lAh'         # all files, human-readable sizes
-alias lm="l | ${PAGER}"   # all files, human-readable sizes, use pager
+[[ -n ${PAGER} ]] && alias lm="l | ${PAGER}" # all files, human-readable sizes, use pager
 alias ll='ls -lh'         # human-readable sizes
 alias lr='ll -R'          # human-readable sizes, recursive
 alias lx='ll -XB'         # human-readable sizes, sort by extension (GNU only)
@@ -98,7 +108,7 @@ fi
 
 # not aliasing rm -i, but if safe-rm is available, use condom.
 # if safe-rmdir is available, the OS is suse which has its own terrible 'safe-rm' which is not what we want
-if (( ${+commands[safe-rm]} )) && (( ! ${+commands[safe-rmdir]} )); then
+if (( ${+commands[safe-rm]} && ! ${+commands[safe-rmdir]} )); then
   alias rm='safe-rm'
 fi
 


### PR DESCRIPTION
In the utility module:
- Set `less` termcap colour variables, and update the module README.md.
- Change the code to enclose all colour logic within a `(( ${terminfo[colors]} >= 8 ))` condition.
- Check if `PAGER` is set before setting the `lm` alias.

In the environment module:
- Set `less` (if available) or `more` as `PAGER`, if `PAGER` is not set.

Keeping the British "colour" spelling. :-)

Closes #76
