### PR TITLE
use setopt NO_CLOBBER instead of unsetopt CLOBBER

### DIFF
--- a/modules/directory/README.md
+++ b/modules/directory/README.md
@@ -12,7 +12,7 @@ ZSH options
 | AUTO_PUSHD | After cd, push the old directory to the directory stack |
 | PUSHD_IGNORE_DUPS | Don't push multiple copies of the same directory to the stack |
 | PUSHD_SILENT | Don't print the directory after pushd or popd |
-| PUSHD_TO_HOME | pushd without arguments acts like 'pushd ${HOME}' |
-| EXTENDED_GLOB | Treat '#', '~', and '^' as patterns for filename globbing |
+| PUSHD_TO_HOME | pushd without arguments acts like `pushd ${HOME}` |
+| EXTENDED_GLOB | Treat `#`, `~`, and `^` as patterns for filename globbing |
 | MULTIOS | Performs implicit tees or cats when using redirections |
-| CLOBBER | Disables automatic truncation with '>' or '>\|'. Use '>>!' or '>>\|' instead |
+| NO_CLOBBER | Disables overwrite existing files with `>`. Use `>|` or `>!` instead |

--- a/modules/directory/init.zsh
+++ b/modules/directory/init.zsh
@@ -6,7 +6,7 @@
 # Navigation
 #
 
-# If a command is issued that can’t be executed as a normal command, 
+# If a command is issued that can’t be executed as a normal command,
 # and the command is the name of a directory, perform the cd command to that directory.
 setopt AUTO_CD
 
@@ -33,6 +33,6 @@ setopt EXTENDED_GLOB
 # Perform implicit tees or cats when multiple redirections are attempted.
 setopt MULTIOS
 
-# Allows ‘>’ redirection to truncate existing files. Otherwise ‘>!’ or ‘>|’ must be used to truncate a file.
-# If the option is not set, and the option APPEND_CREATE is also not set, ‘>>!’ or ‘>>|’ must be used to create a file.
-unsetopt CLOBBER
+# Disallow ‘>’ redirection to overwrite existing files.
+# ‘>|’ or ‘>!’ must be used to overwrite a file.
+setopt NO_CLOBBER


### PR DESCRIPTION
zsh has a NO_CLOBBER option, which does exactly the same with unsetopt CLOBBER
https://github.com/zsh-users/zsh/blob/master/NEWS#L1183

use that we will have a clearer explanation.

I also correct the doc.

What NO_CLOBBER does is actually
- prevent `>` to overwrite existing file. use `>|` or `>!` to force.
- prevent `>>` to create non-existing file, use `>>|` or `>>!` to force. 