### PR TITLE
fix warning when logging in on tty (variable not set)

### DIFF
--- a/modules/utility/init.zsh
+++ b/modules/utility/init.zsh
@@ -6,7 +6,8 @@
 # Colours
 #
 
-if (( ${terminfo[colors]} >= 8 )); then
+COLORS=${terminfo[colors]}
+if (( ${COLORS:=0} >= 8 )); then
   # ls Colors
   if (( ${+commands[dircolors]} )); then
     # GNU

--- a/modules/utility/init.zsh
+++ b/modules/utility/init.zsh
@@ -6,8 +6,7 @@
 # Colours
 #
 
-COLORS=${terminfo[colors]}
-if (( ${COLORS:=0} >= 8 )); then
+if [[ ! -z ${terminfo[colors]} ]] && (( ${terminfo[colors]} >= 8 )); then
   # ls Colors
   if (( ${+commands[dircolors]} )); then
     # GNU


### PR DESCRIPTION
When logging in on the TTY on OpenBSD, the variable $terminfo[colors] is not set, which results in an error while comparing with 8.

Since $terminfo is a read-only variable, i had to take care of the value extraction first before comparing the results, using 0 as the default value if $terminfo[colors] is unset.