### PR TITLE
Add insertmode indicator for default prompts

### DIFF
--- a/modules/prompt/themes/eriner.zsh-theme
+++ b/modules/prompt/themes/eriner.zsh-theme
@@ -141,6 +141,12 @@ prompt_eriner_main() {
 prompt_eriner_precmd() {
   vcs_info
   PROMPT='%{%f%b%k%}$(prompt_eriner_main) '
+  RPROMPT="${${KEYMAP/vicmd/[NORMAL]}/(main|viins)/}"
+}
+
+zle-keymap-slect() {
+        prompt_eriner_precmd
+        zle reset-prompt
 }
 
 prompt_eriner_setup() {
@@ -149,7 +155,9 @@ prompt_eriner_setup() {
 
   prompt_opts=(cr subst percent)
 
-  add-zsh-hook precmd prompt_eriner_precmd
+  add-zsh-hook prompt_eriner_precmd
+
+  zle -N zle-keymap-select
 
   zstyle ':vcs_info:*' enable git
   zstyle ':vcs_info:*' check-for-changes false

--- a/modules/prompt/themes/eriner.zsh-theme
+++ b/modules/prompt/themes/eriner.zsh-theme
@@ -141,7 +141,7 @@ prompt_eriner_main() {
 prompt_eriner_precmd() {
   vcs_info
   PROMPT='%{%f%b%k%}$(prompt_eriner_main) '
-  RPROMPT="${${KEYMAP/vicmd/[NORMAL]}/(main|viins)/}"
+  RPROMPT="${ZIM_PROMPT_INSERTMODE:+${${KEYMAP/vicmd/[NORMAL]}/(main|viins)/}}"
 }
 
 zle-keymap-slect() {

--- a/modules/prompt/themes/eriner.zsh-theme
+++ b/modules/prompt/themes/eriner.zsh-theme
@@ -157,7 +157,7 @@ prompt_eriner_setup() {
 
   add-zsh-hook prompt_eriner_precmd
 
-  zle -N zle-keymap-select
+  [[ "$ZIM_PROMPT_INSERTMODE" != '' ]] && zle -N zle-keymap-select
 
   zstyle ':vcs_info:*' enable git
   zstyle ':vcs_info:*' check-for-changes false

--- a/modules/prompt/themes/gitster.zsh-theme
+++ b/modules/prompt/themes/gitster.zsh-theme
@@ -15,6 +15,12 @@ prompt_gitster_get_pwd() {
 
 prompt_gitster_precmd() {
   [[ ${+functions[git-info]} ]] && git-info
+  RPROMPT="${${KEYMAP/vicmd/[NORMAL]}/(main|viins)/}"
+}
+
+zle-keymap-select() {
+    prompt_gitster_precmd
+    zle reset-prompt
 }
 
 prompt_gitster_setup() {
@@ -24,6 +30,8 @@ prompt_gitster_setup() {
   prompt_opts=(cr percent subst)
 
   add-zsh-hook precmd prompt_gitster_precmd
+  
+  zle -N zle-keymap-select
 
   zstyle ':zim:git-info:branch' format '%b'
   zstyle ':zim:git-info:commit' format '%c'

--- a/modules/prompt/themes/gitster.zsh-theme
+++ b/modules/prompt/themes/gitster.zsh-theme
@@ -15,7 +15,8 @@ prompt_gitster_get_pwd() {
 
 prompt_gitster_precmd() {
   [[ ${+functions[git-info]} ]] && git-info
-  RPROMPT="${${KEYMAP/vicmd/[NORMAL]}/(main|viins)/}"
+  PROMPT='$(prompt_gitster_get_status)%F{white}$(prompt_gitster_get_pwd)${(e)git_info[prompt]}%f '
+  RPROMPT="${ZIM_PROMPT_INSERTMODE:+${${KEYMAP/vicmd/[NORMAL]}/(main|viins)/}}"
 }
 
 zle-keymap-select() {
@@ -39,9 +40,6 @@ prompt_gitster_setup() {
   zstyle ':zim:git-info:dirty' format '%F{yellow}✗'
   zstyle ':zim:git-info:keys' format \
     'prompt' ' %F{cyan}%b%c %C%D'
-
-  PROMPT='$(prompt_gitster_get_status)%F{white}$(prompt_gitster_get_pwd)${(e)git_info[prompt]}%f '
-  RPROMPT=''
 }
 
 prompt_gitster_setup "$@"

--- a/modules/prompt/themes/gitster.zsh-theme
+++ b/modules/prompt/themes/gitster.zsh-theme
@@ -32,7 +32,7 @@ prompt_gitster_setup() {
 
   add-zsh-hook precmd prompt_gitster_precmd
   
-  zle -N zle-keymap-select
+  [[ "$ZIM_PROMPT_INSERTMODE" != '' ]] && zle -N zle-keymap-select
 
   zstyle ':zim:git-info:branch' format '%b'
   zstyle ':zim:git-info:commit' format '%c'

--- a/modules/prompt/themes/magicmace.zsh-theme
+++ b/modules/prompt/themes/magicmace.zsh-theme
@@ -44,6 +44,13 @@ prompt_magicmace_precmd() {
   if [[ ${+functions[git-info]} ]]; then
     git-info
   fi
+  PROMPT='${COLOR_USER_LEVEL}$(prompt_magicmace_status)[${COLOR_NORMAL}$(short_pwd)${COLOR_USER_LEVEL}]${(e)git_info[prompt]}── ─%f '
+  RPROMPT="${${KEYMAP/vicmd/[NORMAL]}/(main|viins)/}"
+}
+
+zle-keymap-select() {
+    prompt_magicmace_precmd
+    zle reset-prompt
 }
 
 prompt_magicmace_setup() {
@@ -63,8 +70,6 @@ prompt_magicmace_setup() {
     'prompt' '─[${COLOR_NORMAL}%b%c%D%A%B${COLOR_USER_LEVEL}]'
 
   # Call git directly, ignoring aliases under the same name.
-  PROMPT='${COLOR_USER_LEVEL}$(prompt_magicmace_status)[${COLOR_NORMAL}$(short_pwd)${COLOR_USER_LEVEL}]${(e)git_info[prompt]}── ─%f '
-  RPROMPT=''
 }
 
 prompt_magicmace_setup "$@"

--- a/modules/prompt/themes/magicmace.zsh-theme
+++ b/modules/prompt/themes/magicmace.zsh-theme
@@ -45,7 +45,7 @@ prompt_magicmace_precmd() {
     git-info
   fi
   PROMPT='${COLOR_USER_LEVEL}$(prompt_magicmace_status)[${COLOR_NORMAL}$(short_pwd)${COLOR_USER_LEVEL}]${(e)git_info[prompt]}── ─%f '
-  RPROMPT="${${KEYMAP/vicmd/[NORMAL]}/(main|viins)/}"
+  RPROMPT="${ZIM_PROMPT_INSERTMODE:+${${KEYMAP/vicmd/[NORMAL]}/(main|viins)/}}"
 }
 
 zle-keymap-select() {

--- a/modules/prompt/themes/magicmace.zsh-theme
+++ b/modules/prompt/themes/magicmace.zsh-theme
@@ -61,6 +61,8 @@ prompt_magicmace_setup() {
 
   add-zsh-hook precmd prompt_magicmace_precmd
 
+  [[ "$ZIM_PROMPT_INSERTMODE" != '' ]] && zle -N zle-keymap-select
+
   zstyle ':zim:git-info:branch' format '%b'
   zstyle ':zim:git-info:commit' format '%c...'
   zstyle ':zim:git-info:dirty' format '*'

--- a/modules/prompt/themes/steeef.zsh-theme
+++ b/modules/prompt/themes/steeef.zsh-theme
@@ -40,9 +40,15 @@ prompt_steeef_precmd() {
     vcs_info 'prompt'
   fi
 
+  RPROMPT="${${KEYMAP/vicmd/[NORMAL]}/(main|viins)/}"
   PROMPT='
 %{$purple%}%n${${reset_color}%} at %{$orange%}%m${${reset_color}%} in %{$limegreen%}%~${${reset_color}%} $vcs_info_msg_0_$(virtualenv_info)%{${reset_color}%}
 %(!.#.$) '
+}
+
+zle-keymap-select() {
+    prompt_steeef_precmd
+    zle reset-prompt
 }
 
 prompt_steeef_setup() {
@@ -96,6 +102,7 @@ prompt_steeef_setup() {
   add-zsh-hook preexec steeef_preexec
   add-zsh-hook chpwd steeef_chpwd
   add-zsh-hook precmd prompt_steeef_precmd
+  zle -N zle-keymap-select
   prompt_opts=(cr subst percent)
 }
 

--- a/modules/prompt/themes/steeef.zsh-theme
+++ b/modules/prompt/themes/steeef.zsh-theme
@@ -40,7 +40,7 @@ prompt_steeef_precmd() {
     vcs_info 'prompt'
   fi
 
-  RPROMPT="${${KEYMAP/vicmd/[NORMAL]}/(main|viins)/}"
+  RPROMPT="${ZIM_PROMPT_INSERTMODE:+${${KEYMAP/vicmd/[NORMAL]}/(main|viins)/}}"
   PROMPT='
 %{$purple%}%n${${reset_color}%} at %{$orange%}%m${${reset_color}%} in %{$limegreen%}%~${${reset_color}%} $vcs_info_msg_0_$(virtualenv_info)%{${reset_color}%}
 %(!.#.$) '

--- a/modules/prompt/themes/steeef.zsh-theme
+++ b/modules/prompt/themes/steeef.zsh-theme
@@ -102,7 +102,7 @@ prompt_steeef_setup() {
   add-zsh-hook preexec steeef_preexec
   add-zsh-hook chpwd steeef_chpwd
   add-zsh-hook precmd prompt_steeef_precmd
-  zle -N zle-keymap-select
+  [[ "$ZIM_PROMPT_INSERTMODE" != '' ]] && zle -N zle-keymap-select
   prompt_opts=(cr subst percent)
 }
 


### PR DESCRIPTION
I apologize my terribleness with git and the need for me to create a new pull request.

This creates a RPROMPT variable that is enabled by the ZIM_PROMPT_INSERTMODE variable's existence. It then binds a zle widget to redraw the prompt with an indicator depicting command mode.