### PR TITLE
Fix fasd completion (no submodule)

### DIFF
--- a/modules/fasd/functions/_fasd_preexec
+++ b/modules/fasd/functions/_fasd_preexec
@@ -1,1 +1,0 @@
-{ eval "fasd --proc $(fasd --sanitize $2)"; } >> "/dev/null" 2>&1

--- a/modules/fasd/functions/_fasd_zsh_cmd_complete
+++ b/modules/fasd/functions/_fasd_zsh_cmd_complete
@@ -1,5 +1,0 @@
-# zsh command mode completion
-local compl
-read -c compl
-(( $+compstate )) && compstate[insert]=menu # no expand if compsys loaded
-reply=(${(f)"$(fasd --complete "$compl")"})

--- a/modules/fasd/functions/fasd_cd
+++ b/modules/fasd/functions/fasd_cd
@@ -1,8 +1,0 @@
-# function to execute built-in cd
-if [ $# -le 1 ]; then
-  fasd "$@"
-else
-  local _fasd_ret="$(fasd -e 'printf %s' "$@")"
-  [ -z "$_fasd_ret" ] && return 1
-  [ -d "$_fasd_ret" ] && cd "$_fasd_ret" || printf %s\n "$_fasd_ret"
-fi


### PR DESCRIPTION
As @Eriner said in  #132, this is fix without adding `fasd` as submodule. 

- Fix word completion for fasd
- Fix initialization script to have all fasd-related functions inside it
  (functions was not called properly when they was in separate files)
- Add another alias `v` for fasd that will access recently used files
  from .viminfo

Fixes: #111
