### PR TITLE
Only evaluate prompt_gitster_status once

### DIFF
--- a/modules/prompt/themes/gitster.zsh-theme
+++ b/modules/prompt/themes/gitster.zsh-theme
@@ -5,7 +5,7 @@
 # Requires the `git-info` zmodule to be included in the .zimrc file.
 
 prompt_gitster_status() {
-  print -n '%(?:%F{green}➜:%F{red}➜) '
+  print -n '%(?:%F{green}:%F{red})➜ '
 }
 
 prompt_gitster_pwd() {
@@ -37,7 +37,7 @@ prompt_gitster_setup() {
   zstyle ':zim:git-info:keys' format \
     'prompt' ' %F{cyan}%b%c %C%D'
 
-  PROMPT='$(prompt_gitster_status)$(prompt_gitster_pwd)$(prompt_gitster_git)%f '
+  PROMPT="$(prompt_gitster_status)\$(prompt_gitster_pwd)\$(prompt_gitster_git)%f "
   RPROMPT=''
 }
 


### PR DESCRIPTION
replacing its contents directly into the `PROMPT`, instead of calling the function continuously.