### PR TITLE
Rewrite minimal theme using git-info

### DIFF
--- a/modules/git-info/README.md
+++ b/modules/git-info/README.md
@@ -48,16 +48,22 @@ a style is:
 | action    |   %s   | Special action name (see Special Action Contexts below)
 | ahead     |   %A   | Commits ahead of remote count
 | behind    |   %B   | Commits behind of remote count
+| diverged  |   %V   | Diverged commits (both ahead and behind are yield when it's not defined)
 | branch    |   %b   | Branch name
 | commit    |   %c   | Commit short hash (when in 'detached HEAD' state)
 | clean     |   %C   | Clean state
-| dirty     |   %D   | Dirty state (count with untracked files if verbose enabled)
-| indexed   |   %i   | Indexed files (count if verbose enabled)
-| unindexed |   %I   | Unindexed files (count if verbose enabled)
+| dirty     |   %D   | Dirty state (count with untracked files when verbose mode enabled)
+| indexed   |   %i   | Indexed files (count when verbose mode enabled)
+| unindexed |   %I   | Unindexed files (count when verbose mode enabled)
 | position  |   %p   | Commits from nearest tag count (when in 'detached HEAD' state)
 | remote    |   %R   | Remote name
 | stashed   |   %S   | Stashed states count
-| untracked |   %u   | Untracked files count (only if verbose enabled)
+| untracked |   %u   | Untracked files count (only when verbose mode enabled)
+
+While `commit` and `position` are only available when in ['detached HEAD'
+state](http://gitfaq.org/articles/what-is-a-detached-head.html), on the other
+hand, `ahead`, `behind`, `diverged`, `branch` and `remote` are only available
+when an actual branch is checked out (so when **not** in 'detached HEAD' state).
 
 ### Special Action Contexts
 

--- a/modules/git-info/functions/coalesce
+++ b/modules/git-info/functions/coalesce
@@ -1,0 +1,6 @@
+# Prints the first non-empty string in the arguments array.
+for arg in ${argv}; do
+  print -n ${arg}
+  return 0
+done
+return 1

--- a/modules/git-info/init.zsh
+++ b/modules/git-info/init.zsh
@@ -100,22 +100,6 @@ git-info() {
     return 1
   fi
 
-  if (( $# )); then
-    if [[ $1 == [Oo][Nn] ]]; then
-      git config --bool prompt.showinfo true
-    elif [[ $1 == [Oo][Ff][Ff] ]]; then
-      git config --bool prompt.showinfo false
-    else
-      print "usage: $0 [ on | off ]" >&2
-    fi
-    return 0
-  fi
-
-  # Return if git-info is disabled.
-  if ! is-true ${$(git config --bool prompt.showinfo):-true}; then
-    return 1
-  fi
-
   # Ignore submodule status.
   local ignore_submodules
   zstyle -s ':zim:git-info' ignore-submodules 'ignore_submodules' || ignore_submodules='all'


### PR DESCRIPTION
- Add `diverged` context to git-info that, when defined, will be set if branch is both ahead and behind of remote. If not defined, the `ahead` and `behind` contexts will still be set, as how they worked previously.
- Remove undocumented git-info configuration `prompt.showinfo` for enabling or disabling it globally or per repository. It can be globally disabled by not loading the `git-info` module at all, and prompts currently will not break (and in the future should still not break) if the module is not loaded. This removes one git call that is used to check for the `prompt.showinfo` configuration value.
- Add `coalesce` function to git-info that will be used by the minimal theme, and could be used for future themes too. Prezto had this, but we diminished its necessity by simplifying how git-info works.
- Finally, rewrite minimal theme using git-info. As previous migrations of themes to git-info, this does not use its verbose mode, so a repo with just untracked files is not considered dirty. It uses the newly-introduced `diverged` context and `coalesce` function from git-info.