### PR TITLE
Add git-info zmodule to templates/zimrc

### DIFF
--- a/templates/zimrc
+++ b/templates/zimrc
@@ -9,9 +9,9 @@
 #
 
 # Select what modules you would like enabled.
-# The second line of modules may depend on options set by modules in the first line.
-# These dependencies are noted on the respective module's README.md.
-zmodules=(directory environment git history input utility meta custom \
+# The second line of modules may depend on options set by modules in the first
+# line. These dependencies are noted on the respective module's README.md.
+zmodules=(directory environment git git-info history input utility meta custom \
           syntax-highlighting history-substring-search prompt completion)
 
 


### PR DESCRIPTION
so it is enabled by default in new Zim installations.