### PR TITLE
Prevent directory change to .zim after running zmanage update

### DIFF
--- a/tools/zim_update
+++ b/tools/zim_update
@@ -11,4 +11,4 @@ git merge --ff-only @\{u\}
 git submodule update --init --recursive
 
 # return to previous directory after update
-cd ~-
+cd $OLDPWD

--- a/tools/zim_update
+++ b/tools/zim_update
@@ -9,3 +9,6 @@ git remote update -p
 git merge --ff-only @\{u\}
 # and update the submodules
 git submodule update --init --recursive
+
+# return to previous directory after update
+cd ~-


### PR DESCRIPTION
Should be able to run `zmanage update` without being redirected into the .zim folder after it is finished running

**Change**
Return to the previous directory after updating from upstream and updating submodules