### PR TITLE
[git] git-commit-lost: fix typo

### DIFF
--- a/modules/git/functions/git-commit-lost
+++ b/modules/git/functions/git-commit-lost
@@ -1,4 +1,4 @@
-if ! is-true "$(commmand git rev-parse --is-inside-work-tree 2> /dev/null)"; then
+if ! is-true "$(command git rev-parse --is-inside-work-tree 2> /dev/null)"; then
   print "${0}: not a repository work tree: ${PWD}" >&2
   return 1
 fi


### PR DESCRIPTION
command is written with two m, not three.
