### PR TITLE
Rewrite steeef theme using git-info

### DIFF
--- a/modules/git-info/README.md
+++ b/modules/git-info/README.md
@@ -100,5 +100,5 @@ Second, format how the above attributes are displayed in prompts:
       'rprompt' '[%R]'
 
 Last, add `$git_info[prompt]` to `$PROMPT` and `$git_info[rprompt]` to
-`$RPROMPT` respectively and call `git-info` in the `prompt_name_preexec` hook
+`$RPROMPT` respectively and call `git-info` in the `prompt_name_precmd` hook
 function.

--- a/modules/git-info/init.zsh
+++ b/modules/git-info/init.zsh
@@ -258,15 +258,11 @@ git-info() {
     local untracked
     # Get current status.
     while IFS=$'\n' read line; do
-      # T (type change) is undocumented, see http://git.io/FnpMGw.
-      if [[ ${line} == \?\?\ * ]]; then
+      if [[ ${line:0:2} == '??' ]]; then
         (( untracked++ ))
-      elif [[ ${line} == \ [DMT]\ * ]]; then
-        (( unindexed++ ))
-      elif [[ ${line} == [ACDMRT]\ \ * ]]; then
-        (( indexed++ ))
-      elif [[ ${line} == ([ACMRT][DMT]|D[MT])\ * ]]; then
-        (( indexed++, unindexed++ ))
+      else
+        [[ ${line:0:1} != ' ' ]] && (( indexed++ ))
+        [[ ${line:1:1} != ' ' ]] && (( unindexed++ ))
       fi
       (( dirty++ ))
     done < <(${(z)status_cmd} 2>/dev/null)


### PR DESCRIPTION
- Change git-info verbose mode implementation so it behaves alike the non-verbose mode. For example, in the "merge" special action context, files are being reported as both indexed and unindexed by `git diff-index` and `git diff-files` commands in non-verbose mode. That was not the case with the regular expressions used in the verbose mode.

- Rewrite steeef theme using git-info. This uses the verbose mode to be able to display indexed, unindexed and untracked files indicators. This is the last theme left to be migrated to git-info, and the first one to use its verbose mode. Originally, the theme also supported svn via vcs_info. The svn support is lost in this rewrite. Maybe if a new svn-info module is introduced to Zim...