### PR TITLE
fix url quote magic

### DIFF
--- a/modules/environment/init.zsh
+++ b/modules/environment/init.zsh
@@ -13,9 +13,9 @@ if [[ ${ZSH_VERSION} != 5.1.1 ]]; then
       autoload -Uz bracketed-paste-magic
       zle -N bracketed-paste bracketed-paste-magic
     fi
-    autoload -Uz url-quote-magic
-    zle -N self-insert url-quote-magic
   fi
+  autoload -Uz url-quote-magic
+  zle -N self-insert url-quote-magic
 fi
 
 # Treat single word simple commands without redirection as candidates for resumption of an existing job.


### PR DESCRIPTION
`url-quote-magic` automatically escapes characters that fit a URI scheme
as you type. From what I can tell from the commit history, this was
mistakenly placed in `else` branch of the nested conditional instead of
at the end of the outermost conditional.

Please follow Zim's [code style guidelines](https://github.com/Eriner/zim/wiki/Code-Style-Guide).
