### PR TITLE
Remove git dependency on is-true function

### DIFF
--- a/modules/git/functions/git-commit-lost
+++ b/modules/git/functions/git-commit-lost
@@ -1,4 +1,4 @@
-if ! is-true "$(command git rev-parse --is-inside-work-tree 2> /dev/null)"; then
+if ! command git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
   print "${0}: not a repository work tree: ${PWD}" >&2
   return 1
 fi

--- a/modules/git/functions/git-stash-clear-interactive
+++ b/modules/git/functions/git-stash-clear-interactive
@@ -1,4 +1,4 @@
-if ! is-true "$(command git rev-parse --is-inside-work-tree 2> /dev/null)"; then
+if ! command git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
   print "${0}: not a repository work tree: ${PWD}" >&2
   return 1
 fi

--- a/modules/git/functions/git-stash-dropped
+++ b/modules/git/functions/git-stash-dropped
@@ -1,4 +1,4 @@
-if ! is-true "$(command git rev-parse --is-inside-work-tree 2> /dev/null)"; then
+if ! command git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
   print "${0}: not a repository work tree: ${PWD}" >&2
   return 1
 fi

--- a/modules/git/functions/git-stash-recover
+++ b/modules/git/functions/git-stash-recover
@@ -1,4 +1,4 @@
-if ! is-true "$(command git rev-parse --is-inside-work-tree 2> /dev/null)"; then
+if ! command git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
   print "${0}: not a repository work tree: ${PWD}" >&2
   return 1
 fi

--- a/modules/git/functions/git-submodule-move
+++ b/modules/git/functions/git-submodule-move
@@ -1,4 +1,4 @@
-if ! is-true "$(command git rev-parse --is-inside-work-tree 2> /dev/null)"; then
+if ! command git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
   print "${0}: not a repository work tree: ${PWD}" >&2
   return 1
 elif [[ "${PWD}" != "$(git-root)" ]]; then

--- a/modules/git/functions/git-submodule-remove
+++ b/modules/git/functions/git-submodule-remove
@@ -1,4 +1,4 @@
-if ! is-true "$(command git rev-parse --is-inside-work-tree 2> /dev/null)"; then
+if ! command git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
   print "${0}: not a repository work tree: ${PWD}" >&2
   return 1
 elif [[ "${PWD}" != "$(git-root)" ]]; then

--- a/modules/git/functions/is-true
+++ b/modules/git/functions/is-true
@@ -1,3 +1,0 @@
-# Checks a boolean variable for "true".
-# Case insensitive: "1", "y", "yes", "t", "true", "o", and "on".
-[[ -n ${1} && ${1} == (1|[Yy]([Ee][Ss]|)|[Tt]([Rr][Uu][Ee]|)|[Oo]([Nn]|)) ]]


### PR DESCRIPTION
- The function is currently only being used for checking the result of `git rev-parse --is-inside-work-tree`. Checking for the return code of the command is enough.
- Remove is-true function that was only being used in the `git` and `git-info` modules to check the output of `git rev-parse --is-inside-work-tree`. The code depending on this function was already changed.