### PR TITLE
[prompt] Fix liquidprompt preview

### DIFF
--- a/modules/prompt/functions/prompt_liquidprompt_setup
+++ b/modules/prompt/functions/prompt_liquidprompt_setup
@@ -1,13 +1,12 @@
 prompt_liquidprompt_setup() {
   autoload -Uz ex-liquidprompt
-
   ext-liquidprompt
-  prompt_opts=(cr subst percent)
 }
 
 prompt_liquidprompt_preview() {
   _lp_set_prompt
   prompt_preview_theme liquidprompt
+  prompt_off
 }
 
 prompt_liquidprompt_setup "$@"


### PR DESCRIPTION
breaking the current prompt after `prompt -p`. Actually liquidprompt is pretty invasive in the way it is implemented, defining extra `prompt_on`, `prompt_off` and `prompt_OFF` functions to switch it after it is executed.

Fixes #112