### PR TITLE
[prompt] Don't expand git_info in eriner theme

### DIFF
--- a/modules/prompt/themes/eriner.zsh-theme
+++ b/modules/prompt/themes/eriner.zsh-theme
@@ -68,7 +68,7 @@ prompt_eriner_git() {
   if [[ -n ${git_info} ]]; then
     local indicator
     [[ ${git_info[color]} == yellow ]] && indicator='± '
-    prompt_eriner_segment ${git_info[color]} " %F{black}${(e)git_info[prompt]} ${indicator}"
+    prompt_eriner_segment ${git_info[color]} ' %F{black}${(e)git_info[prompt]} ${indicator}'
   fi
 }
 

--- a/modules/prompt/themes/eriner.zsh-theme
+++ b/modules/prompt/themes/eriner.zsh-theme
@@ -42,26 +42,19 @@ prompt_eriner_end() {
 # Each component will draw itself, or hide itself if no information needs to be
 # shown.
 
-# Status: Was there an error? Am I root? Are there background jobs? Who and
-# where am I (user@hostname)?
+# Status: Was there an error? Am I root? Are there background jobs? Ranger
+# spawned shell? Who and where am I (user@hostname)?
 prompt_eriner_status() {
   local segment=''
   (( ${RETVAL} )) && segment+=' %F{red}✘'
   (( ${UID} == 0 )) && segment+=' %F{yellow}⚡'
   (( $(jobs -l | wc -l) > 0 )) && segment+=' %F{cyan}⚙'
+  (( ${RANGER_LEVEL} )) && segment+=' %F{cyan}r'
   if [[ ${USER} != ${DEFAULT_USER} || -n ${SSH_CLIENT} ]]; then
      segment+=' %F{%(!.yellow.default)}${USER}@%m'
   fi
   if [[ -n ${segment} ]]; then
     prompt_eriner_segment black "${segment} "
-  fi
-}
-
-# Ranger: <https://github.com/ranger/ranger>, which can spawn a shell under its
-# own process.
-prompt_eriner_ranger() {
-  if (( ${RANGER_LEVEL} )); then
-    prompt_eriner_segment blue ' %F{black}r '
   fi
 }
 
@@ -83,7 +76,6 @@ prompt_eriner_git() {
 prompt_eriner_main() {
   RETVAL=$?
   prompt_eriner_status
-  prompt_eriner_ranger
   prompt_eriner_pwd
   prompt_eriner_git
   prompt_eriner_end


### PR DESCRIPTION
to avoid the git-info vulnerability to execute an arbitrary command, as reported in #158.

Also, change range segment in eriner theme to show as in magicmace. As suggested in https://github.com/Eriner/zim/pull/142#issuecomment-283806756 (and "thumb-upped" by @Tmplt). The Ranger segment was introduced in eriner theme by @Tmplt in #64. He also added it to the magicmace theme.