### PR TITLE
[history-substring-search] Remove redundant defaults

### DIFF
--- a/modules/history-substring-search/init.zsh
+++ b/modules/history-substring-search/init.zsh
@@ -5,11 +5,6 @@
 # source script
 source ${0:h}/external/zsh-history-substring-search.zsh || return 1
 
-# set options
-HISTORY_SUBSTRING_SEARCH_HIGHLIGHT_FOUND='bg=magenta,fg=white,bold'
-HISTORY_SUBSTRING_SEARCH_HIGHLIGHT_NOT_FOUND='bg=red,fg=white,bold'
-HISTORY_SUBSTRING_SEARCH_GLOBBING_FLAGS='i'
-
 # bind UP and DOWN keys
 bindkey "${terminfo[kcuu1]}" history-substring-search-up
 bindkey "${terminfo[kcud1]}" history-substring-search-down


### PR DESCRIPTION
for options already defined, with the same values, in `zsh-history-substring-search.zsh`. See https://github.com/zsh-users/zsh-history-substring-search/blob/be0fe1fca94c2eea3c3798de3c36acfcebf16943/zsh-history-substring-search.zsh#L46-L48