### PR TITLE
init.zsh: Allow arbitrary ZIM location

### DIFF
--- a/init.zsh
+++ b/init.zsh
@@ -3,7 +3,9 @@
 #
 
 # Define zim location
-ZIM="${ZDOTDIR:-${HOME}}/.zim"
+if [[ -z "${ZIM_PATH}" ]]; then
+  ZIM_PATH="${ZDOTDIR:-${HOME}}/.zim"
+fi
 
 # Source user configuration
 if [[ -s "${ZDOTDIR:-${HOME}}/.zimrc" ]]; then
@@ -14,9 +16,9 @@ load_zim_module() {
   local wanted_module
 
   for wanted_module (${zmodules}); do
-    if [[ -s "${ZIM}/modules/${wanted_module}/init.zsh" ]]; then
-      source "${ZIM}/modules/${wanted_module}/init.zsh"
-    elif [[ ! -d "${ZIM}/modules/${wanted_module}" ]]; then
+    if [[ -s "${ZIM_PATH}/modules/${wanted_module}/init.zsh" ]]; then
+      source "${ZIM_PATH}/modules/${wanted_module}/init.zsh"
+    elif [[ ! -d "${ZIM_PATH}/modules/${wanted_module}" ]]; then
       print "No such module \"${wanted_module}\"." >&2
     fi
   done
@@ -27,12 +29,12 @@ load_zim_function() {
   local mod_function
 
   # autoload searches fpath for function locations; add enabled module function paths
-  fpath=(${${zmodules}:+${ZIM}/modules/${^zmodules}/functions(/FN)} ${fpath})
+  fpath=(${${zmodules}:+${ZIM_PATH}/modules/${^zmodules}/functions(/FN)} ${fpath})
 
   function {
     setopt LOCAL_OPTIONS EXTENDED_GLOB
 
-    for mod_function in ${ZIM}/modules/${^zmodules}/functions/${~function_glob}; do
+    for mod_function in ${ZIM_PATH}/modules/${^zmodules}/functions/${~function_glob}; do
       autoload -Uz ${mod_function}
     done
   }


### PR DESCRIPTION
This change allow arbitrary ZIM location path by setting a new environment variable, `ZIM_PATH`. If the user does not set it, ZIM falls back to the old `"${ZDOTDIR:-${HOME}}/.zim"` location.

The object of this change is to make ZIM location more flexible and also helps with development (you can set this variable to a development version of ZIM to local test it).