### PR TITLE
Warning message for zsh < 5.2

### DIFF
--- a/init.zsh
+++ b/init.zsh
@@ -2,6 +2,11 @@
 # Zim initializition
 #
 
+autoload -Uz is-at-least
+if ! is-at-least 5.2; then
+  print "WARNING: Support for zsh < 5.2 will be moved to an unsupported branch on the next update. Please consider updating your zsh version." >&2
+fi
+
 # Define zim location
 ZIM="${ZDOTDIR:-${HOME}}/.zim"
 


### PR DESCRIPTION
as discussed in #184. We'll first give users this warning message. Next update will replace this by an error.

Also, starting at next update, a new branch will be created for users that still want to stick with zsh < 5.2.