### PR TITLE
add recognize comments, for compliant with bash/oh-my-zsh

### DIFF
--- a/modules/environment/README.md
+++ b/modules/environment/README.md
@@ -15,6 +15,7 @@ ZSH Options
 | AUTO_RESUME | Resume existing jobs before creating a new job |
 | LONG_LIST_JOBS | Use the verbose list format by default |
 | NOTIFY | Report job status immediately instead of waiting for new prompt |
+| INTERACTIVE_COMMENTS | Recognize comments starting with `#` |
 | BG_NICE | Disabled to prevent jobs being given a lower priority |
 | HUP | Disabed to prevent SIGHUP to jobs on shell close |
 | CHECK_JOBS | Disabled to prevent job report on shell close |

--- a/modules/environment/init.zsh
+++ b/modules/environment/init.zsh
@@ -27,6 +27,9 @@ setopt LONG_LIST_JOBS
 # Report the status of background jobs immediately, rather than waiting until just before printing a prompt.
 setopt NOTIFY
 
+# Recognize comments starting with `#`.
+setopt INTERACTIVE_COMMENTS
+
 # Run all background jobs at a lower priority. This option is set by default.
 unsetopt BG_NICE
 


### PR DESCRIPTION
Hi, somebody is used to adding `#` after a command for comment.
This is a good habit for searching back history command.

PS: I have done some more work on the master branch in my fork.
if it looks good for you, I will pull them.