### PR TITLE
Add brew completions

### DIFF
--- a/modules/completion/init.zsh
+++ b/modules/completion/init.zsh
@@ -15,6 +15,11 @@ fi
 # add the completions to the fpath
 fpath=(${0:h}/external/src ${fpath})
 
+# add the brew completions to the fpath
+if (( $+commands[brew] )); then
+  fpath=($(brew --prefix)/share/zsh/site-functions ${fpath})
+fi
+
 # load and initialize the completion system
 autoload -Uz compinit && compinit -C -d "${ZDOTDIR:-${HOME}}/${zcompdump_file:-.zcompdump}"
 


### PR DESCRIPTION
Add brew completions. 
zsh-completions removed a lot of completions, e.g. docker, docker-machine. 