### PR TITLE
Don't load zim if zsh < 5.2

### DIFF
--- a/init.zsh
+++ b/init.zsh
@@ -4,7 +4,8 @@
 
 autoload -Uz is-at-least
 if ! is-at-least 5.2; then
-  print "WARNING: Support for zsh < 5.2 will be removed in a future update. Update your version of zsh now to prevent any interruptions." >&2
+  print "ERROR: Zim didn't start. You're using zsh version ${ZSH_VERSION}, and versions < 5.2 are not supported. Update your zsh." >&2
+  return 1
 fi
 
 # Define zim location

--- a/modules/environment/init.zsh
+++ b/modules/environment/init.zsh
@@ -3,20 +3,10 @@
 #
 
 # use smart URL pasting and escaping
-autoload -Uz is-at-least
-if [[ ${ZSH_VERSION} != 5.1.1 ]]; then
-  if is-at-least 5.2; then
-    autoload -Uz bracketed-paste-url-magic
-    zle -N bracketed-paste bracketed-paste-url-magic
-  else
-    if is-at-least 5.1; then
-      autoload -Uz bracketed-paste-magic
-      zle -N bracketed-paste bracketed-paste-magic
-    fi
-  fi
-  autoload -Uz url-quote-magic
-  zle -N self-insert url-quote-magic
-fi
+autoload -Uz bracketed-paste-url-magic
+zle -N bracketed-paste bracketed-paste-url-magic
+autoload -Uz url-quote-magic
+zle -N self-insert url-quote-magic
 
 # Treat single word simple commands without redirection as candidates for resumption of an existing job.
 setopt AUTO_RESUME


### PR DESCRIPTION
and show an error message, as discussed in #184.

Code in modules/environment/init.zsh is also simplified to only support zsh >= 5.2