### PR TITLE
Start zsh 5.0 branch

### DIFF
--- a/init.zsh
+++ b/init.zsh
@@ -3,8 +3,9 @@
 #
 
 autoload -Uz is-at-least
-if ! is-at-least 5.2; then
-  print "WARNING: Support for zsh < 5.2 will be removed in a future update. Update your version of zsh now to prevent any interruptions." >&2
+if ! is-at-least 5.0; then
+  print "ERROR: Zim didn't start. You're using zsh version ${ZSH_VERSION}, and versions < 5.0 are not supported. Update your zsh." >&2
+  return 1
 fi
 
 # Define zim location

--- a/modules/git-info/init.zsh
+++ b/modules/git-info/init.zsh
@@ -178,7 +178,8 @@ git-info() {
       local ahead_and_behind_cmd='command git rev-list --count --left-right HEAD...@{upstream}'
 
       # Get ahead and behind counts.
-      local ahead_and_behind=$(${(z)ahead_and_behind_cmd} 2>/dev/null)
+      local ahead_and_behind
+      ahead_and_behind=$(${(z)ahead_and_behind_cmd} 2>/dev/null)
       local ahead=${ahead_and_behind[(w)1]}
       local behind=${ahead_and_behind[(w)2]}
 


### PR DESCRIPTION
Fail loading zim if zsh version < 5.0.
Also fix git-info failing in zsh 5.0.8 as reported in #176 and #177.
