### PR TITLE
Make zim location configurable and install to XDG_DATA_HOME by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,13 +42,13 @@ Installing Zim is easy. If you have a different shell framework installed (like 
 
 1. In a Zsh shell, clone the repository:
   ```
-  git clone --recursive https://github.com/Eriner/zim.git ${ZDOTDIR:-${HOME}}/.zim
+  git clone --recursive https://github.com/Eriner/zim.git "${XDG_DATA_HOME:-"${HOME}/.local/share"}/zim"
   ```
 
 2. Paste this into your terminal to prepend the initialization templates to your configs:
   ```
   setopt EXTENDED_GLOB
-  for template_file ( ${ZDOTDIR:-${HOME}}/.zim/templates/* ); do
+  for template_file ( ${ZIM_DATA_DIR}/templates/* ); do
     user_file="${ZDOTDIR:-${HOME}}/.${template_file:t}"
     touch ${user_file}
     ( print -rn "$(<${template_file})$(<${user_file})" >! ${user_file} ) 2>/dev/null
@@ -81,7 +81,7 @@ For more information about the `zmanage` tool, see the [meta module][meta-module
 Uninstalling
 ------------
 
-The best way to remove zim is to manually delete `~/.zim`, `~/.zimrc`, and
+The best way to remove zim is to manually delete `~/.local/share/zim`, `~/.zimrc`, and
 remove the initialization lines from your `~/.zshrc`.
 
 However, there are some **experimental** convenience functions to remove zim:

--- a/init.zsh
+++ b/init.zsh
@@ -9,7 +9,14 @@ if ! is-at-least 5.2; then
 fi
 
 # Define zim location
-ZIM="${ZDOTDIR:-${HOME}}/.zim"
+(( ! ${+ZIM_DATA_DIR} )) && \
+  if [[ -d "${XDG_DATA_HOME:-"${HOME}/.local/share"}/zim" ]]; then
+    export ZIM_DATA_DIR="${XDG_DATA_HOME:-"${HOME}/.local/share"}/zim"
+  elif [[ -d "${ZDOTDIR:-${HOME}}/.zim" ]]; then
+    export ZIM_DATA_DIR="${ZDOTDIR:-${HOME}}/.zim"
+  else
+    export ZIM_DATA_DIR="${XDG_DATA_HOME:-"${HOME}/.local/share"}/zim"
+  fi
 
 # Source user configuration
 if [[ -s "${ZDOTDIR:-${HOME}}/.zimrc" ]]; then
@@ -20,9 +27,9 @@ load_zim_module() {
   local wanted_module
 
   for wanted_module (${zmodules}); do
-    if [[ -s "${ZIM}/modules/${wanted_module}/init.zsh" ]]; then
-      source "${ZIM}/modules/${wanted_module}/init.zsh"
-    elif [[ ! -d "${ZIM}/modules/${wanted_module}" ]]; then
+    if [[ -s "${ZIM_DATA_DIR}/modules/${wanted_module}/init.zsh" ]]; then
+      source "${ZIM_DATA_DIR}/modules/${wanted_module}/init.zsh"
+    elif [[ ! -d "${ZIM_DATA_DIR}/modules/${wanted_module}" ]]; then
       print "No such module \"${wanted_module}\"." >&2
     fi
   done
@@ -33,12 +40,12 @@ load_zim_function() {
   local mod_function
 
   # autoload searches fpath for function locations; add enabled module function paths
-  fpath=(${${zmodules}:+${ZIM}/modules/${^zmodules}/functions(/FN)} ${fpath})
+  fpath=(${${zmodules}:+${ZIM_DATA_DIR}/modules/${^zmodules}/functions(/FN)} ${fpath})
 
   function {
     setopt LOCAL_OPTIONS EXTENDED_GLOB
 
-    for mod_function in ${ZIM}/modules/${^zmodules}/functions/${~function_glob}; do
+    for mod_function in ${ZIM_DATA_DIR}/modules/${^zmodules}/functions/${~function_glob}; do
       autoload -Uz ${mod_function}
     done
   }

--- a/modules/custom/functions/example_function
+++ b/modules/custom/functions/example_function
@@ -1,4 +1,4 @@
 # this is an example function
 # running 'example_function' in a zsh session will execute the code below
 
-print "executed example function: ${ZDOTDIR:-${HOME}}/modules/custom/functions/example_function!"
+print "executed example function: ${ZIM_DATA_DIR}/modules/custom/functions/example_function!"

--- a/modules/debug/functions/trace-zim
+++ b/modules/debug/functions/trace-zim
@@ -43,9 +43,9 @@ cp ${ZDOTDIR:-${HOME}}/.zshrc /tmp/ztrace/.zshrc.orig
 cp ${ZDOTDIR:-${HOME}}/.zimrc /tmp/ztrace/.zimrc
 # rsync will allow us to not have to copy the .git folder; use if available 
 if (( ${+commands[rsync]} )); then
-  rsync -az --exclude .git ${ZDOTDIR:-${HOME}}/.zim /tmp/ztrace/
+  rsync -az --exclude .git ${ZIM_DATA_DIR} /tmp/ztrace/
 else
-  cp -R ${ZDOTDIR:-${HOME}}/.zim /tmp/ztrace/
+  cp -R ${ZIM_DATA_DIR} /tmp/ztrace/
 fi
 
 # create a modified .zshrc to produce a trace log

--- a/modules/meta/functions/zmanage
+++ b/modules/meta/functions/zmanage
@@ -16,7 +16,7 @@ if (( ${#} != 1 )); then
 fi
 
 local tools
-tools="${ZIM}/tools"
+tools="${ZIM_DATA_DIR}/tools"
 
 case ${1} in
   update)      zsh ${tools}/zim_update
@@ -33,7 +33,7 @@ case ${1} in
                ;;
   reset)       zsh ${tools}/zim_reset
                ;;
-  debug)       zsh ${ZIM}/modules/debug/functions/trace-zim
+  debug)       zsh ${ZIM_DATA_DIR}/modules/debug/functions/trace-zim
                ;;
   *)           print ${usage}
                ;;

--- a/templates/zlogin
+++ b/templates/zlogin
@@ -17,7 +17,7 @@
     fi
   }
 
-  zim_mods=${ZDOTDIR:-${HOME}}/.zim/modules
+  zim_mods=${ZIM_DATA_DIR}/modules
   setopt EXTENDED_GLOB
 
   # zcompile the completion cache; siginificant speedup.

--- a/templates/zshrc
+++ b/templates/zshrc
@@ -4,8 +4,11 @@
 # User configuration sourced by interactive shells
 #
 
+# Define zim location 
+(( ! ${+ZIM_DATA_DIR} )) && export ZIM_DATA_DIR="${XDG_DATA_HOME:-"${HOME}/.local/share"}/zim"
+
 # Source zim
-if [[ -s ${ZDOTDIR:-${HOME}}/.zim/init.zsh ]]; then
-  source ${ZDOTDIR:-${HOME}}/.zim/init.zsh
+if [[ -s "${ZIM_DATA_DIR}/init.zsh" ]]; then
+  source "${ZIM_DATA_DIR}/init.zsh"
 fi
 

--- a/tools/zim_build_cache
+++ b/tools/zim_build_cache
@@ -2,4 +2,4 @@
 # zim_build_cache - rebuilds the zim cache
 #
 
-source ${ZDOTDIR:-${HOME}}/.zim/templates/zlogin
+source ${ZIM_DATA_DIR}/templates/zlogin

--- a/tools/zim_clean_cache
+++ b/tools/zim_clean_cache
@@ -2,7 +2,7 @@
 # zim_clean_cache - removes all zcompiled files
 #
 
-find ${ZDOTDIR:-${HOME}}/.zim/ -iname '*.zwc' | xargs rm
+find ${ZIM_DATA_DIR} -iname '*.zwc' | xargs rm
 rm -f ${ZDOTDIR:-${HOME}}/.{zshrc.zwc,zcompdump,zcompdump.zwc}
 
 print 'To rebuild the completion cache, please restart your terminal'

--- a/tools/zim_info
+++ b/tools/zim_info
@@ -2,7 +2,7 @@
 # zim_info - prints zim and system info
 #
 
-cd ${ZDOTDIR:-${HOME}}/.zim
+cd ${ZIM_DATA_DIR}
 
 print "Zim commit ref:   $(command git rev-parse --short HEAD)"
 print "Zsh version:      $(command zsh --version)"

--- a/tools/zim_issue
+++ b/tools/zim_issue
@@ -24,7 +24,7 @@ if ! waiter_func; then
 fi
 
 # for convenience, this is our new home
-cd ${ZDOTDIR:-${HOME}}/.zim
+cd ${ZIM_DATA_DIR}
 
 # collect sys info
 git_dirty=$(command git status --porcelain 2>/dev/null | tail -n1)
@@ -64,7 +64,7 @@ done
 
 # if we have a dirty git, report it
 if [[ -n ${git_dirty} ]]; then
-  print "${ZDOTDIR:-${HOME}}/.zim has a dirty git working tree."
+  print "${ZIM_DATA_DIR} has a dirty git working tree."
   print "here is the diff:"
   print '```'
   print $(command git diff)

--- a/tools/zim_remove
+++ b/tools/zim_remove
@@ -10,4 +10,4 @@ sed '/# The following code helps/,/) &!/d' ${ZDOTDIR:-${HOME}}/.zlogin
 rm -f ${ZDOTDIR:-${HOME}}/.zimrc
 
 # not forcing this one, as it is recursive. It's possible something went wrong.
-rm -r ${ZDOTDIR:-${HOME}}/.zim/
+rm -r ${ZIM_DATA_DIR}

--- a/tools/zim_reset
+++ b/tools/zim_reset
@@ -2,5 +2,5 @@
 # zim_reset - resets the zim repository to latest commit
 #
 
-cd ${ZDOTDIR:-${HOME}}/.zim
+cd ${ZIM_DATA_DIR}
 git reset --hard

--- a/tools/zim_update
+++ b/tools/zim_update
@@ -2,7 +2,7 @@
 # zim_update - update the zim repository
 #
 
-cd ${ZDOTDIR:-${HOME}/.zim}
+cd ${ZIM_DATA_DIR}
 
 # this is the cleanest way I know how to update a repository
 git remote update -p


### PR DESCRIPTION
Supersedes https://github.com/Eriner/zim/pull/203. Zims location can be set with ZIM_DATA_DIR and the default is XDG_DATA_HOME (~/.local/share) per the [XDG Base Directory Specification](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html).

My only concern left with this PR is whether we want to print a message when zim is launched from the old directory. Users would have to update the location definition in their .zshrc but after that they could just run `mv ~/.zim ~/.local/share/zim`.