### PR TITLE
[template] Use zrecompile and create digest zwc file

### DIFF
--- a/init.zsh
+++ b/init.zsh
@@ -9,44 +9,33 @@ if ! is-at-least 5.2; then
 fi
 
 # Define zim location
-(( ! ${+ZIM_HOME} )) && export ZIM_HOME="${ZDOTDIR:-${HOME}}/.zim"
+(( ! ${+ZIM_HOME} )) && export ZIM_HOME=${ZDOTDIR:-${HOME}}/.zim
 
 # Source user configuration
-if [[ -s "${ZDOTDIR:-${HOME}}/.zimrc" ]]; then
-  source "${ZDOTDIR:-${HOME}}/.zimrc"
-fi
+[[ -s ${ZDOTDIR:-${HOME}}/.zimrc ]] && source ${ZDOTDIR:-${HOME}}/.zimrc
 
-load_zim_module() {
-  local wanted_module
-
-  for wanted_module (${zmodules}); do
-    if [[ -s "${ZIM_HOME}/modules/${wanted_module}/init.zsh" ]]; then
-      source "${ZIM_HOME}/modules/${wanted_module}/init.zsh"
-    elif [[ ! -d "${ZIM_HOME}/modules/${wanted_module}" ]]; then
-      print "No such module \"${wanted_module}\"." >&2
-    fi
-  done
-}
-
-load_zim_function() {
-  local function_glob='^([_.]*|prompt_*_setup|README*)(-.N:t)'
+# Autoload module functions
+() {
   local mod_function
+  setopt LOCAL_OPTIONS EXTENDED_GLOB
 
   # autoload searches fpath for function locations; add enabled module function paths
   fpath=(${ZIM_HOME}/functions.zwc ${ZIM_HOME}/modules/prompt/functions ${fpath})
 
-  function {
-    setopt LOCAL_OPTIONS EXTENDED_GLOB
-
-    for mod_function in ${ZIM_HOME}/modules/${^zmodules}/functions/${~function_glob}; do
-      autoload -Uz ${mod_function}
-    done
-  }
+  for mod_function in ${ZIM_HOME}/modules/${^zmodules}/functions/^([_.]*|prompt_*_setup|README*)(-.N:t); do
+    autoload -Uz ${mod_function}
+  done
 }
 
-# initialize zim modules
-load_zim_function
-load_zim_module
+# Initialize modules
+() {
+  local zmodule
 
-unset zmodules
-unfunction load_zim_{module,function}
+  for zmodule (${zmodules}); do
+    if [[ -s ${ZIM_HOME}/modules/${zmodule}/init.zsh ]]; then
+      source ${ZIM_HOME}/modules/${zmodule}/init.zsh
+    elif [[ ! -d ${ZIM_HOME}/modules/${zmodule} ]]; then
+      print "No such module \"${zmodule}\"." >&2
+    fi
+  done
+}

--- a/init.zsh
+++ b/init.zsh
@@ -33,7 +33,7 @@ load_zim_function() {
   local mod_function
 
   # autoload searches fpath for function locations; add enabled module function paths
-  fpath=(${${zmodules}:+${ZIM_HOME}/modules/${^zmodules}/functions(/FN)} ${fpath})
+  fpath=(${ZIM_HOME}/functions.zwc ${ZIM_HOME}/modules/prompt/functions ${fpath})
 
   function {
     setopt LOCAL_OPTIONS EXTENDED_GLOB

--- a/templates/zlogin
+++ b/templates/zlogin
@@ -8,52 +8,38 @@
 #
 
 (
-  # Function to determine the need of a zcompile. If the .zwc file
-  # does not exist, or the base file is newer, we need to compile.
-  # These jobs are asynchronous, and will not impact the interactive shell
-  zcompare() {
-    if [[ -s ${1} && ( ! -s ${1}.zwc || ${1} -nt ${1}.zwc ) ]]; then
-      zcompile ${1}
-    fi
-  }
-
   local zim_mods=${ZIM_HOME}/modules
   setopt EXTENDED_GLOB
+  autoload -U zrecompile
 
   # zcompile the completion cache; siginificant speedup.
   for file in ${ZDOTDIR:-${HOME}}/.zcomp^(*.zwc)(.); do
-    zcompare ${file}
+    zrecompile -pq ${file}
   done
 
   # zcompile .zshrc
-  zcompare ${ZDOTDIR:-${HOME}}/.zshrc
+  zrecompile -pq ${ZDOTDIR:-${HOME}}/.zshrc
 
-  # zcompile some light module init scripts
-  zcompare ${zim_mods}/git/init.zsh
-  zcompare ${zim_mods}/git-info/init.zsh
-  zcompare ${zim_mods}/utility/init.zsh
-  zcompare ${zim_mods}/pacman/init.zsh
-  zcompare ${zim_mods}/spectrum/init.zsh
-  zcompare ${zim_mods}/completion/init.zsh
-  zcompare ${zim_mods}/fasd/init.zsh
-
-  # zcompile all .zsh files in the custom module
-  for file in ${zim_mods}/custom/**/^(README.md|*.zwc)(.); do
-    zcompare ${file}
+  # zcompile all module init scripts
+  for file in ${zim_mods}/*/init.zsh; do
+    zrecompile -pq ${file}
   done
 
   # zcompile all autoloaded functions
-  for file in ${zim_mods}/**/functions/^(*.zwc)(.); do
-    zcompare ${file}
+  zrecompile -pq ${ZIM_HOME}/functions ${zim_mods}/*/functions/^([_.]*|prompt_*_setup|README*|*.zwc)(.)
+
+  # zcompile all prompt setup scripts
+  for file in ${zim_mods}/prompt/functions/prompt_*_setup; do
+    zrecompile -pq ${file}
   done
 
   # syntax-highlighting
   for file in ${zim_mods}/syntax-highlighting/external/highlighters/**^test-data/*.zsh; do
-    zcompare ${file}
+    zrecompile -pq ${file}
   done
-  zcompare ${zim_mods}/syntax-highlighting/external/zsh-syntax-highlighting.zsh
+  zrecompile -pq ${zim_mods}/syntax-highlighting/external/zsh-syntax-highlighting.zsh
 
   # zsh-histery-substring-search
-  zcompare ${zim_mods}/history-substring-search/external/zsh-history-substring-search.zsh
+  zrecompile -pq ${zim_mods}/history-substring-search/external/zsh-history-substring-search.zsh
 
 ) &!

--- a/templates/zlogin
+++ b/templates/zlogin
@@ -8,38 +8,34 @@
 #
 
 (
-  local zim_mods=${ZIM_HOME}/modules
-  setopt EXTENDED_GLOB
+  local file
+  local zmodule
+  setopt LOCAL_OPTIONS EXTENDED_GLOB
   autoload -U zrecompile
-
-  # zcompile the completion cache; siginificant speedup.
-  for file in ${ZDOTDIR:-${HOME}}/.zcomp^(*.zwc)(.); do
-    zrecompile -pq ${file}
-  done
 
   # zcompile .zshrc
   zrecompile -pq ${ZDOTDIR:-${HOME}}/.zshrc
 
-  # zcompile all module init scripts
-  for file in ${zim_mods}/*/init.zsh; do
-    zrecompile -pq ${file}
+  # zcompile enabled module autoloaded functions
+  zrecompile -pq ${ZIM_HOME}/functions ${ZIM_HOME}/modules/${^zmodules}/functions/^([_.]*|prompt_*_setup|README*|*.zwc)(-.N)
+
+  # zcompile enabled module init scripts
+  for zmodule (${zmodules}); do
+    zrecompile -pq ${ZIM_HOME}/modules/${zmodule}/init.zsh
   done
 
-  # zcompile all autoloaded functions
-  zrecompile -pq ${ZIM_HOME}/functions ${zim_mods}/*/functions/^([_.]*|prompt_*_setup|README*|*.zwc)(.)
-
   # zcompile all prompt setup scripts
-  for file in ${zim_mods}/prompt/functions/prompt_*_setup; do
+  for file in ${ZIM_HOME}/modules/prompt/functions/prompt_*_setup; do
     zrecompile -pq ${file}
   done
 
   # syntax-highlighting
-  for file in ${zim_mods}/syntax-highlighting/external/highlighters/**^test-data/*.zsh; do
+  for file in ${ZIM_HOME}/modules/syntax-highlighting/external/highlighters/**^test-data/*.zsh; do
     zrecompile -pq ${file}
   done
-  zrecompile -pq ${zim_mods}/syntax-highlighting/external/zsh-syntax-highlighting.zsh
+  zrecompile -pq ${ZIM_HOME}/modules/syntax-highlighting/external/zsh-syntax-highlighting.zsh
 
   # zsh-histery-substring-search
-  zrecompile -pq ${zim_mods}/history-substring-search/external/zsh-history-substring-search.zsh
+  zrecompile -pq ${ZIM_HOME}/modules/history-substring-search/external/zsh-history-substring-search.zsh
 
 ) &!


### PR DESCRIPTION
for the autoloaded functions. According to the `zshbuiltins` documentation:

    Files containing multiple compiled functions are called `digest'
    files,  and are intended to be used as elements of the FPATH/fpath
    special array.

Also compiling all module init files, instead of some selected ones. This didn't impact performance much (time to run async block in zlogin when from 0.22s to 0.25s on my machine).

Didn't manage to make adding the prompt `prompt_*_setup` functions to the digest file work, so kept these separate.

Closes #86
