### PR TITLE
[completion] Consider the zcompdump_file variable

### DIFF
--- a/modules/completion/init.zsh
+++ b/modules/completion/init.zsh
@@ -23,13 +23,8 @@ source ${0:h}/compdefs.zsh
 
 {
   # zcomple the .zcompdump in the background
-  zcompdump=${ZDOTDIR:-${HOME}}/.zcompdump
-
-  if [[ -s ${zcompdump} && ( ! -s ${zcompdump}.zwc || ${zcompdump} -nt ${zcompdump}.zwc) ]]; then
-    zcompile ${zcompdump}
-  fi
-  
-  unset zcompdump
+  autoload -U zrecompile
+  zrecompile -pq ${ZDOTDIR:-${HOME}}/${zcompdump_file:-.zcompdump}
 } &!
 
 

--- a/modules/meta/functions/zmanage
+++ b/modules/meta/functions/zmanage
@@ -25,7 +25,7 @@ case ${1} in
                ;;
   issue)       zsh ${tools}/zim_issue
                ;;
-  clean-cache) zsh ${tools}/zim_clean_cache && print 'Cleaned cache'
+  clean-cache) source ${tools}/zim_clean_cache && print 'Cleaned cache'
                ;;
   build-cache) source ${tools}/zim_build_cache && print 'Rebuilt cache'
                ;;

--- a/tools/zim_clean_cache
+++ b/tools/zim_clean_cache
@@ -2,7 +2,8 @@
 # zim_clean_cache - removes all zcompiled files
 #
 
-find ${ZIM_HOME} -iname '*.zwc' | xargs rm
-rm -f ${ZDOTDIR:-${HOME}}/.{zshrc.zwc,zcompdump,zcompdump.zwc}
+find ${ZIM_HOME} -iname '*.zwc' -delete
+rm -f ${ZDOTDIR:-${HOME}}/.zshrc.zwc
+rm -f ${ZDOTDIR:-${HOME}}/${zcompdump_file:-.zcompdump}{,.zwc}
 
 print 'To rebuild the completion cache, please restart your terminal'

--- a/tools/zim_clean_cache
+++ b/tools/zim_clean_cache
@@ -2,8 +2,8 @@
 # zim_clean_cache - removes all zcompiled files
 #
 
-find ${ZIM_HOME} -iname '*.zwc' -delete
-rm -f ${ZDOTDIR:-${HOME}}/.zshrc.zwc
-rm -f ${ZDOTDIR:-${HOME}}/${zcompdump_file:-.zcompdump}{,.zwc}
+find ${ZIM_HOME} \( -name '*.zwc' -or -name '*.zwc.old' \) -delete
+rm -f ${ZDOTDIR:-${HOME}}/.zshrc.zwc{,.old}
+rm -f ${ZDOTDIR:-${HOME}}/${zcompdump_file:-.zcompdump}{,.zwc{,.old}}
 
 print 'To rebuild the completion cache, please restart your terminal'


### PR DESCRIPTION
that could be defined in `.zimrc`, when doing the zcompile in `modules/completion/init.zsh` and cleaning the cache.

A custom `${zcompdump_file}` would not be zcompiled or cleaned from the cache without this correction.

Also, use zrecompile instead of the custom logic to call zcompile.
