### PR TITLE
Add Control+A and Control+E shortcuts

### DIFF
--- a/modules/input/init.zsh
+++ b/modules/input/init.zsh
@@ -61,6 +61,9 @@ if [[ -n "${key_info[End]}" ]]; then
   bindkey "${key_info[End]}" end-of-line
 fi
 
+bindkey "${key_info[Control]}A" beginning-of-line
+bindkey "${key_info[Control]}E" end-of-line
+
 if [[ -n "${key_info[PageUp]}" ]]; then
   bindkey "${key_info[PageUp]}" up-line-or-history
 fi


### PR DESCRIPTION
Add Control+A and Control+E shortcuts for beginning of line and end of line.

I've been using these forever, and they are standard in a lot of terminals, I think it would be nice to set them in this module for people who are used to it. 