### PR TITLE
[utility] BSD uses LSCOLORS and GREP_COLOR

### DIFF
--- a/modules/utility/init.zsh
+++ b/modules/utility/init.zsh
@@ -6,38 +6,41 @@
 # Colours
 #
 
-if [[ ! -z ${terminfo[colors]} ]] && (( ${terminfo[colors]} >= 8 )); then
-  # ls Colours
-  if (( ${+commands[dircolors]} )); then
-    # GNU
-    if [[ -s ${HOME}/.dir_colors ]]; then
-      eval "$(dircolors --sh ${HOME}/.dir_colors)"
-    else
-      eval "$(dircolors --sh)"
-    fi
-
-    alias ls='ls --group-directories-first --color=auto'
-
-  else
+if (( terminfo[colors] >= 8 )); then
+  if [[ ${OSTYPE} == (*bsd*|darwin*) ]]; then
     # BSD
 
-    # colours for ls and completion
     (( ! ${+LSCOLORS} )) && export LSCOLORS='exfxcxdxbxGxDxabagacad'
-    (( ! ${+LS_COLORS} )) && export LS_COLORS='di=34:ln=35:so=32:pi=33:ex=31:bd=36;01:cd=33;01:su=31;40;07:sg=36;40;07:tw=32;40;07:ow=33;40;07:'
 
-    # stock OpenBSD ls does not support colors at all, but colorls does.
-    if [[ $OSTYPE == openbsd* ]]; then
+    if [[ ${OSTYPE} == openbsd* ]]; then
+      # stock OpenBSD ls does not support colours at all, but colorls does.
       if (( ${+commands[colorls]} )); then
         alias ls='colorls -G'
       fi
     else
       alias ls='ls -G'
     fi
+
+    (( ! ${+GREP_COLOR} )) && export GREP_COLOR='37;45'
+  else
+    # GNU
+
+    if (( ${+commands[dircolors]} )); then
+      if [[ -s ${HOME}/.dir_colors ]]; then
+        eval "$(dircolors --sh ${HOME}/.dir_colors)"
+      else
+        eval "$(dircolors --sh)"
+      fi
+    else
+      (( ! ${+LS_COLORS} )) && export LS_COLORS='di=34:ln=35:so=32:pi=33:ex=31:bd=1;36:cd=1;33:su=30;41:sg=30;46:tw=30;42:ow=30;43'
+    fi
+
+    alias ls='ls --group-directories-first --color=auto'
+
+    (( ! ${+GREP_COLORS} )) && export GREP_COLORS="mt=37;45"
   fi
 
   # grep Colours
-  (( ! ${+GREP_COLOR} )) && export GREP_COLOR='37;45'               #BSD
-  (( ! ${+GREP_COLORS} )) && export GREP_COLORS="mt=${GREP_COLOR}"  #GNU
   if [[ ${OSTYPE} == openbsd* ]]; then
     if (( ${+commands[ggrep]} )); then
       alias grep='ggrep --color=auto'


### PR DESCRIPTION
and GNU uses LS_COLORS and GREP_COLORS. So change logic to only set these environment variables for each OSTYPE.

Also original code was setting the `ls` alias with `-G` instead of `--color=auto` if in a GNU without `dircolors`. Fix that too.

Simplify arithmetic command expression without using `${var}`, but `var` instead. The second construct does not fail if `var` is not defined, but defaults its value to `0` in that case.