### PR TITLE
[prompt] eriner: Add help, preview, parameters

### DIFF
--- a/modules/prompt/themes/eriner.zsh-theme
+++ b/modules/prompt/themes/eriner.zsh-theme
@@ -1,12 +1,11 @@
-# vim:ts=2 sw=2 sts=2 ft=zsh
+# vim:et sts=2 sw=2 ft=zsh
 #
 # Eriner's Theme - fork of agnoster
 # A Powerline-inspired theme for ZSH
 #
-# In order for this theme to render correctly, you will need a font with
-# powerline symbols. A simple way to add the powerline symbols is to follow the
-# instructions here:
-# https://simplyian.com/2014/03/28/using-powerline-symbols-with-your-current-font/
+# In order for this theme to render correctly, a font with Powerline symbols is
+# required. A simple way to install a font with Powerline symbols is to follow
+# the instructions here: https://github.com/powerline/fonts#installation
 #
 # The aim of this theme is to only show you *relevant* information. Like most
 # prompts, it will only show git information when in a git working directory.
@@ -17,64 +16,86 @@
 #
 # Requires the `git-info` zmodule to be included in the .zimrc file.
 
-### Segment drawing
-# Utility functions to make it easy and re-usable to draw segmented prompts.
+prompt_eriner_help () {
+  cat <<EOH
+This prompt is color-scheme-able. You can customize it using:
 
-local prompt_eriner_bg
+    prompt eriner [<status> [<pwd> [<git_clean> [<git_dirty>]]]]
 
-# Begin a segment. Takes two arguments, background color and contents of the
-# new segment.
-prompt_eriner_segment() {
-  print -n "%K{$1}"
-  if [[ -n ${prompt_eriner_bg} ]]; then
-    print -n "%F{${prompt_eriner_bg}}"
-  fi
-  print -n "$2"
-  prompt_eriner_bg=$1
+where the parameters are the background colors for each segment. The default
+colors are black, cyan, green, yellow.
+
+In order for this prompt to render correctly, a font with Powerline symbols is
+required. A simple way to install a font with Powerline symbols is to follow
+the instructions here: https://github.com/powerline/fonts#installation
+EOH
 }
 
-# End the prompt, closing last segment.
-prompt_eriner_end() {
-  print -n "%k%F{${prompt_eriner_bg}}%f "
-}
-
-### Prompt components
-# Each component will draw itself, or hide itself if no information needs to be
-# shown.
-
-# Status: Was there an error? Am I root? Are there background jobs? Ranger
-# spawned shell? Who and where am I (user@hostname)?
-prompt_eriner_status() {
-  local segment=''
-  (( ${RETVAL} )) && segment+=' %F{red}✘'
-  (( ${UID} == 0 )) && segment+=' %F{yellow}⚡'
-  (( $(jobs -l | wc -l) > 0 )) && segment+=' %F{cyan}⚙'
-  (( ${RANGER_LEVEL} )) && segment+=' %F{cyan}r'
-  if [[ ${USER} != ${DEFAULT_USER} || -n ${SSH_CLIENT} ]]; then
-     segment+=' %F{%(!.yellow.default)}${USER}@%m'
-  fi
-  if [[ -n ${segment} ]]; then
-    prompt_eriner_segment black "${segment} "
-  fi
-}
-
-# Pwd: current working directory.
-prompt_eriner_pwd() {
-  prompt_eriner_segment cyan " %F{black}$(short_pwd) "
-}
-
-# Git: branch/detached head, dirty status.
-prompt_eriner_git() {
-  if [[ -n ${git_info} ]]; then
-    local indicator
-    [[ ${git_info[color]} == yellow ]] && indicator='± '
-    prompt_eriner_segment ${git_info[color]} ' %F{black}${(e)git_info[prompt]} ${indicator}'
-  fi
-}
-
-### Main prompt
 prompt_eriner_main() {
-  RETVAL=$?
+  local prompt_eriner_retval=${?}
+  local prompt_eriner_color1=${1:-black}
+  local prompt_eriner_color2=${2:-cyan}
+
+  ### Segment drawing
+  # Utility functions to make it easy and re-usable to draw segmented prompts.
+
+  local prompt_eriner_bg
+
+  # Begin a segment. Takes two arguments, background color and contents of the
+  # new segment.
+  prompt_eriner_segment() {
+    print -n "%K{${1}}"
+    [[ -n ${prompt_eriner_bg} ]] && print -n "%F{${prompt_eriner_bg}}"
+    print -n "${2}"
+    prompt_eriner_bg=${1}
+  }
+
+  prompt_eriner_standout_segment() {
+    print -n "%S%F{${1}}"
+    [[ -n ${prompt_eriner_bg} ]] && print -n "%K{${prompt_eriner_bg}}%k"
+    print -n "${2}%s"
+    prompt_eriner_bg=${1}
+  }
+
+  # End the prompt, closing last segment.
+  prompt_eriner_end() {
+    print -n "%k%F{${prompt_eriner_bg}}%f "
+  }
+
+  ### Prompt components
+  # Each component will draw itself, or hide itself if no information needs to
+  # be shown.
+
+  # Status: Was there an error? Am I root? Are there background jobs? Ranger
+  # spawned shell? Who and where am I (user@hostname)?
+  prompt_eriner_status() {
+    local segment=''
+    (( prompt_eriner_retval )) && segment+=' %F{red}✘'
+    (( UID == 0 )) && segment+=' %F{yellow}⚡'
+    (( $(jobs -l | wc -l) )) && segment+=' %F{cyan}⚙'
+    (( RANGER_LEVEL )) && segment+=' %F{cyan}r'
+    if [[ ${USER} != ${DEFAULT_USER} || -n ${SSH_CLIENT} ]]; then
+       segment+=' %F{%(!.yellow.default)}${USER}@%m'
+    fi
+    if [[ -n ${segment} ]]; then
+      prompt_eriner_segment ${prompt_eriner_color1} "${segment} "
+    fi
+  }
+
+  # Pwd: current working directory.
+  prompt_eriner_pwd() {
+    prompt_eriner_standout_segment ${prompt_eriner_color2} " $(short_pwd) "
+  }
+
+  # Git: branch/detached head, dirty status.
+  prompt_eriner_git() {
+    if [[ -n ${git_info} ]]; then
+      local indicator
+      [[ ${git_info[color]} == yellow ]] && indicator='± '
+      prompt_eriner_standout_segment ${git_info[color]} " \${(e)git_info[prompt]} ${indicator}"
+    fi
+  }
+
   prompt_eriner_status
   prompt_eriner_pwd
   prompt_eriner_git
@@ -93,17 +114,30 @@ prompt_eriner_setup() {
 
   add-zsh-hook precmd prompt_eriner_precmd
 
+  local prompt_eriner_color3=${3:-green}
+  local prompt_eriner_color4=${4:-yellow}
+
   zstyle ':zim:git-info:branch' format ' %b'
   zstyle ':zim:git-info:commit' format '➦ %c'
   zstyle ':zim:git-info:action' format ' (%s)'
-  zstyle ':zim:git-info:clean' format 'green'
-  zstyle ':zim:git-info:dirty' format 'yellow'
+  zstyle ':zim:git-info:clean' format ${prompt_eriner_color3}
+  zstyle ':zim:git-info:dirty' format ${prompt_eriner_color4}
   zstyle ':zim:git-info:keys' format \
     'prompt' '%b%c%s' \
     'color' '%C%D'
 
-  PROMPT='${(e)$(prompt_eriner_main)}'
+  PROMPT="\${(e)\$(prompt_eriner_main ${@:1:2})}"
   RPROMPT=''
 }
 
-prompt_eriner_setup "$@"
+prompt_eriner_preview () {
+  if (( $# )); then
+    prompt_preview_theme eriner "${@}"
+  else
+    prompt_preview_theme eriner
+    print
+    prompt_preview_theme eriner black blue green yellow
+  fi
+}
+
+prompt_eriner_setup "${@}"


### PR DESCRIPTION
and refactor code, inlining auxiliary functions inside `prompt_eriner_main`.

Theme colors are now customizable with parameters. Also, it works better with light backgrounds by using `%Sstandout%s` for the segments which were originally using black as foreground color (intended for dark backgrounds).

The help explains the parameters, and the preview shows one color variation.