### PR TITLE
[completion] Remove smart editor completion

### DIFF
--- a/modules/completion/init.zsh
+++ b/modules/completion/init.zsh
@@ -96,6 +96,3 @@ zstyle ':completion:*:history-words' menu yes
 # ignore multiple entries.
 zstyle ':completion:*:(rm|kill|diff):*' ignore-line other
 zstyle ':completion:*:rm:*' file-patterns '*:all-files'
-
-# smart editor completion
-zstyle ':completion:*:(nano|vim|nvim|vi|emacs|e):*' ignored-patterns '*.(wav|mp3|flac|ogg|mp4|avi|mkv|webm|iso|dmg|so|o|a|bin|exe|dll|pcap|7z|zip|tar|gz|bz2|rar|deb|pkg|gzip|pdf|mobi|epub|png|jpeg|jpg|gif)'


### PR DESCRIPTION
as Vim can open archives, and Emacs can virtually open everything  :- )

I suggest we don't try to be smart here.